### PR TITLE
Add Patient Risk Contract API support

### DIFF
--- a/athenahealth/client.go
+++ b/athenahealth/client.go
@@ -59,6 +59,11 @@ type Client interface {
 	AddPatientDriversLicenseDocument(ctx context.Context, patientID string, opts *AddPatientDriversLicenseDocumentOptions) (*AddPatientDriversLicenseDocumentResult, error)
 	AddPatientDriversLicenseDocumentReader(ctx context.Context, patientID string, opts *AddPatientDriversLicenseDocumentReaderOptions) (*AddPatientDriversLicenseDocumentResult, error)
 
+	// Patient Risk Contracts
+	ListRiskContracts(ctx context.Context, patientID string, opts *ListRiskContractsOptions) ([]*RiskContract, error)
+	CreateRiskContract(ctx context.Context, patientID string, opts *CreateRiskContractOptions) error
+	DeleteRiskContract(ctx context.Context, patientID string, riskContractID int) error
+
 	// Patient Lab Results
 	AddLabResultDocumentReader(ctx context.Context, patientID string, departmentID string, opts *AddLabResultDocumentOptions) (int, error)
 	ListLabResults(ctx context.Context, patientID string, departmentID string, opts *ListLabResultsOptions) (*ListLabResultsResult, error)

--- a/athenahealth/resources/CreateRiskContract.json
+++ b/athenahealth/resources/CreateRiskContract.json
@@ -1,0 +1,3 @@
+{
+  "success": true
+}

--- a/athenahealth/resources/DeleteRiskContract.json
+++ b/athenahealth/resources/DeleteRiskContract.json
@@ -1,0 +1,3 @@
+{
+  "success": true
+}

--- a/athenahealth/resources/ListRiskContracts.json
+++ b/athenahealth/resources/ListRiskContracts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "contractname": "Medicare Advantage",
+    "effectivedate": "01/01/2024",
+    "expirationdate": "12/31/2024",
+    "riskcontractid": 123
+  },
+  {
+    "contractname": "Commercial HMO",
+    "effectivedate": "06/01/2024",
+    "expirationdate": "05/31/2025",
+    "riskcontractid": 456
+  }
+]

--- a/athenahealth/risk_contracts.go
+++ b/athenahealth/risk_contracts.go
@@ -1,0 +1,94 @@
+package athenahealth
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// RiskContract represents a risk contract associated with a patient
+type RiskContract struct {
+	ContractName  string `json:"contractname"`
+	EffectiveDate string `json:"effectivedate"`
+	ExpirationDate string `json:"expirationdate"`
+	RiskContractID int    `json:"riskcontractid"`
+}
+
+// ListRiskContractsOptions represents options for listing risk contracts
+type ListRiskContractsOptions struct {
+	DepartmentID string
+}
+
+// CreateRiskContractOptions represents options for creating/updating a risk contract
+type CreateRiskContractOptions struct {
+	RiskContractID int
+	EffectiveDate  string // Format: MM/DD/YYYY
+	ExpirationDate string // Format: MM/DD/YYYY (optional)
+}
+
+// ListRiskContracts - Get a list of risk contracts associated with the patient
+//
+// GET /v1/{practiceid}/chart/{patientid}/riskcontract
+//
+// https://docs.athenahealth.com/api/api-ref/patient-risk-contract
+func (h *HTTPClient) ListRiskContracts(ctx context.Context, patientID string, opts *ListRiskContractsOptions) ([]*RiskContract, error) {
+	out := []*RiskContract{}
+
+	q := url.Values{}
+
+	if opts != nil && opts.DepartmentID != "" {
+		q.Add("departmentid", opts.DepartmentID)
+	}
+
+	_, err := h.Get(ctx, fmt.Sprintf("/chart/%s/riskcontract", patientID), q, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// CreateRiskContract - Create a new risk contract for the patient
+//
+// PUT /v1/{practiceid}/chart/{patientid}/riskcontract
+//
+// https://docs.athenahealth.com/api/api-ref/patient-risk-contract
+func (h *HTTPClient) CreateRiskContract(ctx context.Context, patientID string, opts *CreateRiskContractOptions) error {
+	if opts == nil {
+		panic("opts is nil")
+	}
+
+	out := &MessageResponse{}
+
+	form := url.Values{}
+	form.Add("riskcontractid", strconv.Itoa(opts.RiskContractID))
+	form.Add("effectivedate", opts.EffectiveDate)
+
+	if opts.ExpirationDate != "" {
+		form.Add("expirationdate", opts.ExpirationDate)
+	}
+
+	_, err := h.PutForm(ctx, fmt.Sprintf("/chart/%s/riskcontract", patientID), form, &out)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteRiskContract - Delete a risk contract for the patient
+//
+// DELETE /v1/{practiceid}/chart/{patientid}/riskcontract/{riskcontractid}
+//
+// https://docs.athenahealth.com/api/api-ref/patient-risk-contract
+func (h *HTTPClient) DeleteRiskContract(ctx context.Context, patientID string, riskContractID int) error {
+	out := &MessageResponse{}
+
+	_, err := h.Delete(ctx, fmt.Sprintf("/chart/%s/riskcontract/%d", patientID, riskContractID), nil, &out)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/athenahealth/risk_contracts_test.go
+++ b/athenahealth/risk_contracts_test.go
@@ -1,0 +1,153 @@
+package athenahealth
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPClient_ListRiskContracts(t *testing.T) {
+	assert := assert.New(t)
+
+	patientID := "123"
+	departmentID := "456"
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/chart/123/riskcontract", r.URL.Path)
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal(departmentID, r.URL.Query().Get("departmentid"))
+
+		b, _ := os.ReadFile("./resources/ListRiskContracts.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	opts := &ListRiskContractsOptions{
+		DepartmentID: departmentID,
+	}
+
+	contracts, err := athenaClient.ListRiskContracts(context.Background(), patientID, opts)
+	assert.NoError(err)
+	assert.NotNil(contracts)
+	assert.Len(contracts, 2)
+
+	// Verify first contract
+	assert.Equal("Medicare Advantage", contracts[0].ContractName)
+	assert.Equal("01/01/2024", contracts[0].EffectiveDate)
+	assert.Equal("12/31/2024", contracts[0].ExpirationDate)
+	assert.Equal(123, contracts[0].RiskContractID)
+
+	// Verify second contract
+	assert.Equal("Commercial HMO", contracts[1].ContractName)
+	assert.Equal("06/01/2024", contracts[1].EffectiveDate)
+	assert.Equal("05/31/2025", contracts[1].ExpirationDate)
+	assert.Equal(456, contracts[1].RiskContractID)
+}
+
+func TestHTTPClient_ListRiskContracts_WithoutDepartment(t *testing.T) {
+	assert := assert.New(t)
+
+	patientID := "123"
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/chart/123/riskcontract", r.URL.Path)
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Empty(r.URL.Query().Get("departmentid"))
+
+		b, _ := os.ReadFile("./resources/ListRiskContracts.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	contracts, err := athenaClient.ListRiskContracts(context.Background(), patientID, nil)
+	assert.NoError(err)
+	assert.NotNil(contracts)
+}
+
+func TestHTTPClient_CreateRiskContract(t *testing.T) {
+	assert := assert.New(t)
+
+	patientID := "123"
+	opts := &CreateRiskContractOptions{
+		RiskContractID: 789,
+		EffectiveDate:  "01/15/2024",
+		ExpirationDate: "01/14/2025",
+	}
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/chart/123/riskcontract", r.URL.Path)
+		assert.Equal(http.MethodPut, r.Method)
+
+		assert.NoError(r.ParseForm())
+		assert.Equal(strconv.Itoa(opts.RiskContractID), r.Form.Get("riskcontractid"))
+		assert.Equal(opts.EffectiveDate, r.Form.Get("effectivedate"))
+		assert.Equal(opts.ExpirationDate, r.Form.Get("expirationdate"))
+
+		b, _ := os.ReadFile("./resources/CreateRiskContract.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	err := athenaClient.CreateRiskContract(context.Background(), patientID, opts)
+	assert.NoError(err)
+}
+
+func TestHTTPClient_CreateRiskContract_WithoutExpirationDate(t *testing.T) {
+	assert := assert.New(t)
+
+	patientID := "123"
+	opts := &CreateRiskContractOptions{
+		RiskContractID: 789,
+		EffectiveDate:  "01/15/2024",
+	}
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/chart/123/riskcontract", r.URL.Path)
+		assert.Equal(http.MethodPut, r.Method)
+
+		assert.NoError(r.ParseForm())
+		assert.Equal(strconv.Itoa(opts.RiskContractID), r.Form.Get("riskcontractid"))
+		assert.Equal(opts.EffectiveDate, r.Form.Get("effectivedate"))
+		assert.Empty(r.Form.Get("expirationdate"))
+
+		b, _ := os.ReadFile("./resources/CreateRiskContract.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	err := athenaClient.CreateRiskContract(context.Background(), patientID, opts)
+	assert.NoError(err)
+}
+
+func TestHTTPClient_DeleteRiskContract(t *testing.T) {
+	assert := assert.New(t)
+
+	patientID := "123"
+	riskContractID := 789
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/chart/123/riskcontract/789", r.URL.Path)
+		assert.Equal(http.MethodDelete, r.Method)
+
+		b, _ := os.ReadFile("./resources/DeleteRiskContract.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	err := athenaClient.DeleteRiskContract(context.Background(), patientID, riskContractID)
+	assert.NoError(err)
+}


### PR DESCRIPTION
## Add Patient Risk Contract API support

- Add risk_contracts.go with GET/PUT/DELETE methods for managing patient risk contracts
- Add comprehensive unit tests with 5 test cases covering all scenarios
- Add test fixtures (ListRiskContracts.json, CreateRiskContract.json, DeleteRiskContract.json)
- Update client.go interface with risk contract methods
- All tests passing (139 tests total)

## Breaking Changes

N/A