### PR TITLE
fix: correct risk contract reference API response format

### DIFF
--- a/athenahealth/resources/GetRiskContractReference.json
+++ b/athenahealth/resources/GetRiskContractReference.json
@@ -1,8 +1,6 @@
-[
-  {
-    "description": "Medicare Advantage risk sharing contract for value-based care",
-    "name": "Medicare Advantage Contract",
-    "riskcontractid": 123,
-    "success": "true"
-  }
-]
+{
+  "description": "Medicare Advantage risk sharing contract for value-based care",
+  "name": "Medicare Advantage Contract",
+  "riskcontractid": 123,
+  "success": "true"
+}

--- a/athenahealth/resources/UpdateRiskContractReference.json
+++ b/athenahealth/resources/UpdateRiskContractReference.json
@@ -1,6 +1,4 @@
-[
-  {
-    "riskcontractid": 789,
-    "success": "true"
-  }
-]
+{
+  "riskcontractid": 789,
+  "success": "true"
+}

--- a/athenahealth/risk_contracts.go
+++ b/athenahealth/risk_contracts.go
@@ -168,7 +168,7 @@ func (h *HTTPClient) GetRiskContractReference(ctx context.Context, opts *GetRisk
 		panic("either RiskContractID or Name must be provided")
 	}
 
-	out := []*RiskContractReference{}
+	out := &RiskContractReference{}
 
 	q := url.Values{}
 
@@ -180,16 +180,12 @@ func (h *HTTPClient) GetRiskContractReference(ctx context.Context, opts *GetRisk
 		q.Add("name", opts.Name)
 	}
 
-	_, err := h.Get(ctx, "/populationmanagement/riskcontract", q, &out)
+	_, err := h.Get(ctx, "/populationmanagement/riskcontract", q, out)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(out) == 0 {
-		return nil, fmt.Errorf("risk contract not found")
-	}
-
-	return out[0], nil
+	return out, nil
 }
 
 // UpdateRiskContractReferenceOptions represents options for updating/creating a risk contract reference
@@ -216,7 +212,7 @@ func (h *HTTPClient) UpdateRiskContractReference(ctx context.Context, opts *Upda
 		panic("Name is required")
 	}
 
-	out := []*RiskContractReference{}
+	out := &RiskContractReference{}
 
 	form := url.Values{}
 	form.Add("name", opts.Name)
@@ -229,14 +225,10 @@ func (h *HTTPClient) UpdateRiskContractReference(ctx context.Context, opts *Upda
 		form.Add("description", opts.Description)
 	}
 
-	_, err := h.PutForm(ctx, "/populationmanagement/riskcontract", form, &out)
+	_, err := h.PutForm(ctx, "/populationmanagement/riskcontract", form, out)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(out) == 0 {
-		return nil, fmt.Errorf("failed to update risk contract reference")
-	}
-
-	return out[0], nil
+	return out, nil
 }


### PR DESCRIPTION
## correct risk contract reference API response format

- Changed GetRiskContractReference and UpdateRiskContractReference to return single objects instead of arrays
- Updated JSON response files to match athenahealth API documentation
- Removed unnecessary array handling logic in both functions
- All tests pass

## Breaking Changes
n/a
