### PR TITLE
fix: correct risk contract reference response types and add integration test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 playground/*
 
 .idea
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-all: tidy format build test
+all: tidy format lint build test
 
 build:
 	go build ./...
 
 format:
 	go fmt ./...
+
+lint:
+	golangci-lint run --timeout=5m --tests=false
 
 test:
 	go test ./... -race

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ See the athena [Best Practices](https://docs.athenahealth.com/api/guides/best-pr
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for development guidelines.
 
+## Integration Testing
+
+This repository includes an integration test harness for validating API endpoints against the actual athenahealth API. This is useful when:
+
+- Adding new API endpoints
+- Debugging response format issues
+- Verifying API documentation accuracy
+
+### Running Integration Tests
+
+```bash
+# Set your credentials (required)
+export ATHENA_PRACTICE_ID=your-practice-id
+export ATHENA_API_KEY=your-api-key
+export ATHENA_API_SECRET=your-api-secret
+
+# Run all integration tests
+go test -v -run TestIntegration ./athenahealth
+
+# Or use the helper script
+./scripts/run-integration-tests.sh
+```
+
+### Viewing Raw API Responses
+
+Integration tests include special "RawResponse" tests that show the actual JSON returned by the API:
+
+```bash
+# See raw responses for risk contract endpoints
+go test -v -run TestIntegration_.*_RawResponse ./athenahealth
+```
+
+See [athenahealth/INTEGRATION_TESTS.md](athenahealth/INTEGRATION_TESTS.md) for detailed documentation on writing and running integration tests.
+
 ### Release Process
 
 **Important**: This repository uses a special branching strategy for releases.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ This repository includes an integration test harness for validating API endpoint
 ### Running Integration Tests
 
 ```bash
-# Set your credentials (required)
+# Integration tests require explicit opt-in
+export ATHENA_RUN_INTEGRATION_TESTS=true
 export ATHENA_PRACTICE_ID=your-practice-id
 export ATHENA_API_KEY=your-api-key
 export ATHENA_API_SECRET=your-api-secret
@@ -82,7 +83,7 @@ export ATHENA_API_SECRET=your-api-secret
 # Run all integration tests
 go test -v -run TestIntegration ./athenahealth
 
-# Or use the helper script
+# Or use the helper script (sets the flag automatically)
 ./scripts/run-integration-tests.sh
 ```
 

--- a/athenahealth/INTEGRATION_TESTS.md
+++ b/athenahealth/INTEGRATION_TESTS.md
@@ -1,0 +1,97 @@
+# Integration Test Harness
+
+This directory contains integration tests that make real API calls to the athenahealth API. These tests are useful for validating the actual response formats from the API endpoints.
+
+## Setup
+
+Set the following environment variables before running integration tests:
+
+```bash
+export ATHENA_PRACTICE_ID=your-practice-id
+export ATHENA_API_KEY=your-api-key
+export ATHENA_API_SECRET=your-api-secret
+```
+
+These environment variables are **required** - integration tests will fail if they are not set.
+
+## Running Integration Tests
+
+### Run all integration tests:
+```bash
+go test -v -run TestIntegration ./athenahealth
+```
+
+### Run specific integration tests for Risk Contracts:
+```bash
+# Set optional test data
+export ATHENA_TEST_RISK_CONTRACT_ID=123
+export ATHENA_TEST_RISK_CONTRACT_NAME="Test Contract Name"
+
+# Run the tests
+go test -v -run TestIntegration_RiskContract ./athenahealth
+```
+
+### Run raw response tests to see actual API output:
+```bash
+# These tests log the raw JSON response from the API
+go test -v -run TestIntegration_.*_RawResponse ./athenahealth
+```
+
+## Available Integration Tests
+
+### Risk Contract Reference Tests
+
+- `TestIntegration_GetRiskContractReference_RawResponse` - Shows raw API response for GET endpoint
+- `TestIntegration_GetRiskContractReference_ByID` - Tests getting contract by ID
+- `TestIntegration_GetRiskContractReference_ByName` - Tests getting contract by name
+- `TestIntegration_UpdateRiskContractReference_RawResponse` - Shows raw API response for PUT endpoint
+- `TestIntegration_UpdateRiskContractReference_Create` - Tests creating a new contract
+- `TestIntegration_UpdateRiskContractReference_Update` - Tests updating an existing contract
+
+## Creating New Integration Tests
+
+Use the `IntegrationTestClient` helper to create a properly configured client:
+
+```go
+func TestIntegration_MyNewTest(t *testing.T) {
+    client := IntegrationTestClient(t)
+
+    // Your test code here
+    result, err := client.SomeMethod(ctx, opts)
+    if err != nil {
+        t.Fatalf("API call failed: %v", err)
+    }
+
+    // Log the result for inspection
+    LogResponse(t, "Result Description", result)
+}
+```
+
+Use `TestRawAPIResponse` to inspect the raw JSON response format:
+
+```go
+func TestIntegration_MyEndpoint_RawResponse(t *testing.T) {
+    client := IntegrationTestClient(t)
+
+    params := url.Values{}
+    params.Add("param1", "value1")
+
+    // This will print the raw JSON response
+    TestRawAPIResponse(t, client, http.MethodGet, "/path/to/endpoint", params)
+}
+```
+
+## Best Practices
+
+1. Always use the `_RawResponse` tests first to inspect the actual API response format
+2. Don't commit sensitive data or credentials
+3. Use descriptive test names that indicate what endpoint is being tested
+4. Log responses using `LogResponse` for easier debugging
+5. Run integration tests in isolation, not as part of regular unit test runs
+
+## Safety
+
+- Integration tests make **real API calls** and require valid credentials
+- Use a test/sandbox practice ID whenever possible
+- Never commit credentials to version control
+- Be aware of API rate limits when running these tests

--- a/athenahealth/INTEGRATION_TESTS.md
+++ b/athenahealth/INTEGRATION_TESTS.md
@@ -4,15 +4,16 @@ This directory contains integration tests that make real API calls to the athena
 
 ## Setup
 
+Integration tests are **skipped by default** and require explicit opt-in.
+
 Set the following environment variables before running integration tests:
 
 ```bash
+export ATHENA_RUN_INTEGRATION_TESTS=true  # Required to enable integration tests
 export ATHENA_PRACTICE_ID=your-practice-id
 export ATHENA_API_KEY=your-api-key
 export ATHENA_API_SECRET=your-api-secret
 ```
-
-These environment variables are **required** - integration tests will fail if they are not set.
 
 ## Running Integration Tests
 

--- a/athenahealth/integration_test_helper.go
+++ b/athenahealth/integration_test_helper.go
@@ -78,6 +78,7 @@ func TestRawAPIResponse(t *testing.T, client *HTTPClient, method, path string, p
 		resp, err = client.PostForm(ctx, path, params, nil)
 	case http.MethodDelete:
 		resp, err = client.Delete(ctx, path, nil, nil)
+	default:
 		t.Fatalf("Unsupported method: %s", method)
 	}
 
@@ -85,7 +86,7 @@ func TestRawAPIResponse(t *testing.T, client *HTTPClient, method, path string, p
 		t.Fatalf("API call failed: %v", err)
 	}
 
-	if resp != nil && resp.Body != nil {
+	if resp.Body != nil {
 		defer resp.Body.Close()
 
 		var responseData interface{}

--- a/athenahealth/integration_test_helper.go
+++ b/athenahealth/integration_test_helper.go
@@ -11,14 +11,19 @@ import (
 )
 
 // IntegrationTestClient creates a real HTTP client for integration testing.
-// Requires the following environment variables:
+// Integration tests are SKIPPED by default and require explicit opt-in.
+//
+// To run integration tests, set:
+//   - ATHENA_RUN_INTEGRATION_TESTS=true (required to enable)
 //   - ATHENA_PRACTICE_ID
 //   - ATHENA_CLIENT_ID (or ATHENA_API_KEY)
 //   - ATHENA_CLIENT_SECRET (or ATHENA_API_SECRET)
-//
-// Will fail the test if any required credentials are missing.
 func IntegrationTestClient(t *testing.T) *HTTPClient {
 	t.Helper()
+
+	if os.Getenv("ATHENA_RUN_INTEGRATION_TESTS") != "true" {
+		t.Skip("Skipping integration test: Set ATHENA_RUN_INTEGRATION_TESTS=true to run")
+	}
 
 	practiceID := os.Getenv("ATHENA_PRACTICE_ID")
 
@@ -34,7 +39,7 @@ func IntegrationTestClient(t *testing.T) *HTTPClient {
 	}
 
 	if practiceID == "" || clientID == "" || clientSecret == "" {
-		t.Fatal("Required environment variables not set: ATHENA_PRACTICE_ID, ATHENA_CLIENT_ID (or ATHENA_API_KEY), ATHENA_CLIENT_SECRET (or ATHENA_API_SECRET)")
+		t.Fatal("Required environment variables not set: ATHENA_PRACTICE_ID, ATHENA_CLIENT_ID/ATHENA_API_KEY, ATHENA_CLIENT_SECRET/ATHENA_API_SECRET")
 	}
 
 	client := NewHTTPClient(http.DefaultClient, practiceID, clientID, clientSecret)

--- a/athenahealth/integration_test_helper.go
+++ b/athenahealth/integration_test_helper.go
@@ -1,0 +1,98 @@
+package athenahealth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+)
+
+// IntegrationTestClient creates a real HTTP client for integration testing.
+// Requires the following environment variables:
+//   - ATHENA_PRACTICE_ID
+//   - ATHENA_CLIENT_ID (or ATHENA_API_KEY)
+//   - ATHENA_CLIENT_SECRET (or ATHENA_API_SECRET)
+//
+// Will fail the test if any required credentials are missing.
+func IntegrationTestClient(t *testing.T) *HTTPClient {
+	t.Helper()
+
+	practiceID := os.Getenv("ATHENA_PRACTICE_ID")
+
+	// Support both naming conventions
+	clientID := os.Getenv("ATHENA_CLIENT_ID")
+	if clientID == "" {
+		clientID = os.Getenv("ATHENA_API_KEY")
+	}
+
+	clientSecret := os.Getenv("ATHENA_CLIENT_SECRET")
+	if clientSecret == "" {
+		clientSecret = os.Getenv("ATHENA_API_SECRET")
+	}
+
+	if practiceID == "" || clientID == "" || clientSecret == "" {
+		t.Fatal("Required environment variables not set: ATHENA_PRACTICE_ID, ATHENA_CLIENT_ID (or ATHENA_API_KEY), ATHENA_CLIENT_SECRET (or ATHENA_API_SECRET)")
+	}
+
+	client := NewHTTPClient(http.DefaultClient, practiceID, clientID, clientSecret)
+
+	return client
+}
+
+// LogResponse is a helper to log the full response for debugging
+func LogResponse(t *testing.T, description string, v interface{}) {
+	t.Helper()
+
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Logf("Error marshalling %s: %v", description, err)
+		return
+	}
+
+	t.Logf("%s:\n%s", description, string(b))
+}
+
+// TestRawAPIResponse makes a raw API call and logs the response body for inspection
+func TestRawAPIResponse(t *testing.T, client *HTTPClient, method, path string, params url.Values) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	var resp *http.Response
+	var err error
+
+	switch method {
+	case http.MethodGet:
+		resp, err = client.Get(ctx, path, params, nil)
+	case http.MethodPut:
+		resp, err = client.PutForm(ctx, path, params, nil)
+	case http.MethodPost:
+		resp, err = client.PostForm(ctx, path, params, nil)
+	case http.MethodDelete:
+		resp, err = client.Delete(ctx, path, nil, nil)
+		t.Fatalf("Unsupported method: %s", method)
+	}
+
+	if err != nil {
+		t.Fatalf("API call failed: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+
+		var responseData interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&responseData); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		b, _ := json.MarshalIndent(responseData, "", "  ")
+		fmt.Printf("\n=== RAW API RESPONSE ===\n")
+		fmt.Printf("Method: %s\n", method)
+		fmt.Printf("Path: %s\n", path)
+		fmt.Printf("Response:\n%s\n", string(b))
+		fmt.Printf("========================\n\n")
+	}
+}

--- a/athenahealth/resources/GetRiskContractReference.json
+++ b/athenahealth/resources/GetRiskContractReference.json
@@ -2,5 +2,5 @@
   "description": "Medicare Advantage risk sharing contract for value-based care",
   "name": "Medicare Advantage Contract",
   "riskcontractid": 123,
-  "success": "true"
+  "success": true
 }

--- a/athenahealth/resources/UpdateRiskContractReference.json
+++ b/athenahealth/resources/UpdateRiskContractReference.json
@@ -1,4 +1,4 @@
 {
   "riskcontractid": 789,
-  "success": "true"
+  "success": true
 }

--- a/athenahealth/risk_contracts.go
+++ b/athenahealth/risk_contracts.go
@@ -9,8 +9,8 @@ import (
 
 // RiskContract represents a risk contract associated with a patient
 type RiskContract struct {
-	ContractName  string `json:"contractname"`
-	EffectiveDate string `json:"effectivedate"`
+	ContractName   string `json:"contractname"`
+	EffectiveDate  string `json:"effectivedate"`
 	ExpirationDate string `json:"expirationdate"`
 	RiskContractID int    `json:"riskcontractid"`
 }
@@ -98,7 +98,7 @@ func (h *HTTPClient) CreateRiskContract(ctx context.Context, patientID string, o
 
 // DeleteRiskContractOptions represents options for deleting a risk contract
 type DeleteRiskContractOptions struct {
-	DepartmentID int  // Department ID (optional)
+	DepartmentID int // Department ID (optional)
 	// If true, apply this delete to all charts associated with the given patient
 	AllCharts bool
 }

--- a/athenahealth/risk_contracts.go
+++ b/athenahealth/risk_contracts.go
@@ -143,7 +143,7 @@ type RiskContractReference struct {
 	ErrorMessage   string `json:"errormessage"`
 	Name           string `json:"name"`
 	RiskContractID int    `json:"riskcontractid"`
-	Success        string `json:"success"`
+	Success        bool   `json:"success"`
 }
 
 // GetRiskContractReferenceOptions represents options for getting a risk contract reference

--- a/athenahealth/risk_contracts_integration_test.go
+++ b/athenahealth/risk_contracts_integration_test.go
@@ -1,0 +1,185 @@
+package athenahealth
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// Integration tests for Risk Contract Reference endpoints
+// These tests make real API calls to validate response formats
+//
+// To run these tests, set the following environment variables:
+//   export ATHENA_INTEGRATION_TEST=true
+//   export ATHENA_PRACTICE_ID=your-practice-id
+//   export ATHENA_API_KEY=your-api-key
+//   export ATHENA_API_SECRET=your-api-secret
+//   export ATHENA_TEST_RISK_CONTRACT_ID=123  # An existing risk contract ID (optional)
+//   export ATHENA_TEST_RISK_CONTRACT_NAME="Test Contract"  # An existing contract name (optional)
+//
+// Run with: go test -v -run TestIntegration_RiskContract ./athenahealth
+
+func TestIntegration_GetRiskContractReference_RawResponse(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	riskContractID := mustGetEnvInt(t, "ATHENA_TEST_RISK_CONTRACT_ID", true)
+	if riskContractID == 0 {
+		t.Skip("ATHENA_TEST_RISK_CONTRACT_ID not set, skipping")
+	}
+
+	t.Logf("Testing GET /populationmanagement/riskcontract with riskcontractid=%d", riskContractID)
+
+	params := url.Values{}
+	params.Add("riskcontractid", strconv.Itoa(riskContractID))
+
+	TestRawAPIResponse(t, client, http.MethodGet, "/populationmanagement/riskcontract", params)
+}
+
+func TestIntegration_GetRiskContractReference_ByID(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	riskContractID := mustGetEnvInt(t, "ATHENA_TEST_RISK_CONTRACT_ID", true)
+	if riskContractID == 0 {
+		t.Skip("ATHENA_TEST_RISK_CONTRACT_ID not set, skipping")
+	}
+
+	ctx := context.Background()
+	opts := &GetRiskContractReferenceOptions{
+		RiskContractID: riskContractID,
+	}
+
+	result, err := client.GetRiskContractReference(ctx, opts)
+	if err != nil {
+		t.Fatalf("GetRiskContractReference failed: %v", err)
+	}
+
+	LogResponse(t, "GetRiskContractReference Result", result)
+
+	if result.RiskContractID != riskContractID {
+		t.Errorf("Expected RiskContractID=%d, got %d", riskContractID, result.RiskContractID)
+	}
+}
+
+func TestIntegration_GetRiskContractReference_ByName(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	contractName := mustGetEnv(t, "ATHENA_TEST_RISK_CONTRACT_NAME", true)
+	if contractName == "" {
+		t.Skip("ATHENA_TEST_RISK_CONTRACT_NAME not set, skipping")
+	}
+
+	ctx := context.Background()
+	opts := &GetRiskContractReferenceOptions{
+		Name: contractName,
+	}
+
+	result, err := client.GetRiskContractReference(ctx, opts)
+	if err != nil {
+		t.Fatalf("GetRiskContractReference failed: %v", err)
+	}
+
+	LogResponse(t, "GetRiskContractReference Result", result)
+
+	if result.Name != contractName {
+		t.Errorf("Expected Name=%s, got %s", contractName, result.Name)
+	}
+}
+
+func TestIntegration_UpdateRiskContractReference_RawResponse(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	// This test creates a new risk contract reference or updates an existing one
+	t.Log("Testing PUT /populationmanagement/riskcontract")
+
+	params := url.Values{}
+	params.Add("name", "Integration Test Contract")
+	params.Add("description", "Created by integration test")
+
+	// If you want to update an existing contract, uncomment and set:
+	// riskContractID := mustGetEnvInt(t, "ATHENA_TEST_RISK_CONTRACT_ID", true)
+	// if riskContractID > 0 {
+	// 	params.Add("riskcontractid", strconv.Itoa(riskContractID))
+	// }
+
+	TestRawAPIResponse(t, client, http.MethodPut, "/populationmanagement/riskcontract", params)
+}
+
+func TestIntegration_UpdateRiskContractReference_Create(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	ctx := context.Background()
+	opts := &UpdateRiskContractReferenceOptions{
+		Name:        "Integration Test Contract",
+		Description: "Created by integration test",
+	}
+
+	result, err := client.UpdateRiskContractReference(ctx, opts)
+	if err != nil {
+		t.Fatalf("UpdateRiskContractReference failed: %v", err)
+	}
+
+	LogResponse(t, "UpdateRiskContractReference Result (Create)", result)
+
+	if result.RiskContractID == 0 {
+		t.Error("Expected non-zero RiskContractID after creation")
+	}
+}
+
+func TestIntegration_UpdateRiskContractReference_Update(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	riskContractID := mustGetEnvInt(t, "ATHENA_TEST_RISK_CONTRACT_ID", true)
+	if riskContractID == 0 {
+		t.Skip("ATHENA_TEST_RISK_CONTRACT_ID not set, skipping")
+	}
+
+	ctx := context.Background()
+	opts := &UpdateRiskContractReferenceOptions{
+		RiskContractID: riskContractID,
+		Name:           "Updated Integration Test Contract",
+		Description:    "Updated by integration test",
+	}
+
+	result, err := client.UpdateRiskContractReference(ctx, opts)
+	if err != nil {
+		t.Fatalf("UpdateRiskContractReference failed: %v", err)
+	}
+
+	LogResponse(t, "UpdateRiskContractReference Result (Update)", result)
+
+	if result.RiskContractID != riskContractID {
+		t.Errorf("Expected RiskContractID=%d, got %d", riskContractID, result.RiskContractID)
+	}
+}
+
+// Helper functions
+
+func mustGetEnv(t *testing.T, key string, optional bool) string {
+	t.Helper()
+	value := os.Getenv(key)
+	if value == "" && !optional {
+		t.Fatalf("Required environment variable %s not set", key)
+	}
+	return value
+}
+
+func mustGetEnvInt(t *testing.T, key string, optional bool) int {
+	t.Helper()
+	value := os.Getenv(key)
+	if value == "" {
+		if !optional {
+			t.Fatalf("Required environment variable %s not set", key)
+		}
+		return 0
+	}
+
+	intVal, err := strconv.Atoi(value)
+	if err != nil {
+		t.Fatalf("Invalid integer value for %s: %s", key, value)
+	}
+
+	return intVal
+}

--- a/athenahealth/risk_contracts_test.go
+++ b/athenahealth/risk_contracts_test.go
@@ -266,7 +266,7 @@ func TestHTTPClient_GetRiskContractReference_ByID(t *testing.T) {
 	assert.Equal("Medicare Advantage Contract", contract.Name)
 	assert.Equal("Medicare Advantage risk sharing contract for value-based care", contract.Description)
 	assert.Equal(123, contract.RiskContractID)
-	assert.Equal("true", contract.Success)
+	assert.True(contract.Success)
 }
 
 func TestHTTPClient_GetRiskContractReference_ByName(t *testing.T) {
@@ -324,7 +324,7 @@ func TestHTTPClient_UpdateRiskContractReference_Create(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(contract)
 	assert.Equal(789, contract.RiskContractID)
-	assert.Equal("true", contract.Success)
+	assert.True(contract.Success)
 }
 
 func TestHTTPClient_UpdateRiskContractReference_Update(t *testing.T) {
@@ -356,7 +356,7 @@ func TestHTTPClient_UpdateRiskContractReference_Update(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(contract)
 	assert.Equal(789, contract.RiskContractID)
-	assert.Equal("true", contract.Success)
+	assert.True(contract.Success)
 }
 
 func TestHTTPClient_UpdateRiskContractReference_NameOnly(t *testing.T) {

--- a/docs/INTEGRATION_TEST_EXAMPLE.md
+++ b/docs/INTEGRATION_TEST_EXAMPLE.md
@@ -1,0 +1,131 @@
+# Example: Using Integration Tests to Validate Risk Contract Endpoints
+
+This example demonstrates how to use the integration test harness to validate the Risk Contract Reference API endpoints.
+
+## Step 1: Set up your environment
+
+```bash
+export ATHENA_PRACTICE_ID=your-practice-id
+export ATHENA_API_KEY=your-api-key
+export ATHENA_API_SECRET=your-api-secret
+
+# Optional: Set test data if you have existing risk contracts
+export ATHENA_TEST_RISK_CONTRACT_ID=123
+export ATHENA_TEST_RISK_CONTRACT_NAME="Medicare Advantage Contract"
+```
+
+## Step 2: Run raw response tests to see actual API output
+
+This is the most important step - it shows you exactly what the API returns:
+
+```bash
+# See the raw response from GET /populationmanagement/riskcontract
+go test -v -run TestIntegration_GetRiskContractReference_RawResponse ./athenahealth
+
+# See the raw response from PUT /populationmanagement/riskcontract
+go test -v -run TestIntegration_UpdateRiskContractReference_RawResponse ./athenahealth
+```
+
+Example output:
+```
+=== RAW API RESPONSE ===
+Method: GET
+Path: /populationmanagement/riskcontract
+Response:
+{
+  "description": "Medicare Advantage risk sharing contract",
+  "name": "Medicare Advantage Contract",
+  "riskcontractid": 123,
+  "success": "true"
+}
+========================
+```
+
+## Step 3: Compare with your Go struct
+
+Based on the raw response, verify your Go struct matches:
+
+```go
+type RiskContractReference struct {
+    Description    string `json:"description"`
+    ErrorMessage   string `json:"errormessage"`
+    Name           string `json:"name"`
+    RiskContractID int    `json:"riskcontractid"`
+    Success        string `json:"success"`
+}
+```
+
+## Step 4: Run the full integration tests
+
+Once you've confirmed the response format, run the full tests:
+
+```bash
+# Test getting by ID
+go test -v -run TestIntegration_GetRiskContractReference_ByID ./athenahealth
+
+# Test getting by name
+go test -v -run TestIntegration_GetRiskContractReference_ByName ./athenahealth
+
+# Test creating a new contract
+go test -v -run TestIntegration_UpdateRiskContractReference_Create ./athenahealth
+
+# Test updating an existing contract
+go test -v -run TestIntegration_UpdateRiskContractReference_Update ./athenahealth
+```
+
+## Step 5: Or use the helper script
+
+```bash
+# Run all integration tests
+./scripts/run-integration-tests.sh
+
+# Run only risk contract tests
+./scripts/run-integration-tests.sh TestIntegration_RiskContract
+```
+
+## Troubleshooting
+
+### Unmarshalling errors
+
+If you get unmarshalling errors, run the `_RawResponse` tests first to see the actual API response format. Common issues:
+
+1. **Array vs Object**: Check if the API returns `[{...}]` or just `{...}`
+2. **Field types**: Verify `int` vs `string` for numeric fields
+3. **Missing fields**: Check if the API returns fields not in your struct
+4. **Extra fields**: Your struct can have fields the API doesn't return (they'll be zero values)
+
+### Authentication errors
+
+Make sure your credentials are valid and you have access to the endpoint in your practice.
+
+### 404 errors
+
+The endpoint might not be available in your practice's API version or configuration.
+
+## Creating Your Own Integration Tests
+
+Use this pattern to create integration tests for other endpoints:
+
+```go
+func TestIntegration_MyEndpoint_RawResponse(t *testing.T) {
+    client := IntegrationTestClient(t)
+
+    params := url.Values{}
+    params.Add("param1", "value1")
+
+    TestRawAPIResponse(t, client, http.MethodGet, "/path/to/endpoint", params)
+}
+
+func TestIntegration_MyEndpoint(t *testing.T) {
+    client := IntegrationTestClient(t)
+
+    result, err := client.MyMethod(context.Background(), "arg1", opts)
+    if err != nil {
+        t.Fatalf("MyMethod failed: %v", err)
+    }
+
+    LogResponse(t, "MyMethod Result", result)
+
+    // Add assertions here
+}
+```

--- a/docs/INTEGRATION_TEST_EXAMPLE.md
+++ b/docs/INTEGRATION_TEST_EXAMPLE.md
@@ -5,6 +5,9 @@ This example demonstrates how to use the integration test harness to validate th
 ## Step 1: Set up your environment
 
 ```bash
+# Enable integration tests (required)
+export ATHENA_RUN_INTEGRATION_TESTS=true
+
 export ATHENA_PRACTICE_ID=your-practice-id
 export ATHENA_API_KEY=your-api-key
 export ATHENA_API_SECRET=your-api-secret

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Integration Test Runner Script
+# This script helps run integration tests with proper environment setup
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== Athenahealth Integration Test Runner ===${NC}\n"
+
+# Check if required environment variables are set
+if [ -z "$ATHENA_PRACTICE_ID" ] || [ -z "$ATHENA_API_KEY" ] || [ -z "$ATHENA_API_SECRET" ]; then
+    echo -e "${RED}Error: Required environment variables not set${NC}"
+    echo ""
+    echo "Please set the following environment variables:"
+    echo "  export ATHENA_PRACTICE_ID=your-practice-id"
+    echo "  export ATHENA_API_KEY=your-api-key"
+    echo "  export ATHENA_API_SECRET=your-api-secret"
+    echo ""
+    echo "Optional variables for Risk Contract tests:"
+    echo "  export ATHENA_TEST_RISK_CONTRACT_ID=123"
+    echo "  export ATHENA_TEST_RISK_CONTRACT_NAME=\"Contract Name\""
+    echo ""
+    exit 1
+fi
+
+echo -e "${GREEN}Environment configuration:${NC}"
+echo "  ATHENA_PRACTICE_ID: ${ATHENA_PRACTICE_ID}"
+echo "  ATHENA_API_KEY: ${ATHENA_API_KEY:0:10}..."
+echo "  ATHENA_API_SECRET: ${ATHENA_API_SECRET:0:10}..."
+echo ""
+
+if [ -n "$ATHENA_TEST_RISK_CONTRACT_ID" ]; then
+    echo "  ATHENA_TEST_RISK_CONTRACT_ID: ${ATHENA_TEST_RISK_CONTRACT_ID}"
+fi
+
+if [ -n "$ATHENA_TEST_RISK_CONTRACT_NAME" ]; then
+    echo "  ATHENA_TEST_RISK_CONTRACT_NAME: ${ATHENA_TEST_RISK_CONTRACT_NAME}"
+fi
+
+echo ""
+
+# Determine which tests to run
+TEST_PATTERN="${1:-TestIntegration}"
+
+echo -e "${YELLOW}Running tests matching: ${TEST_PATTERN}${NC}\n"
+
+# Run the tests
+cd "$(dirname "$0")"
+go test -v -run "${TEST_PATTERN}" ./athenahealth
+
+echo ""
+echo -e "${GREEN}✓ Tests completed${NC}"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -45,6 +45,9 @@ fi
 
 echo ""
 
+# Enable integration tests
+export ATHENA_RUN_INTEGRATION_TESTS=true
+
 # Determine which tests to run
 TEST_PATTERN="${1:-TestIntegration}"
 


### PR DESCRIPTION
## fix: correct risk contract reference response types and add integration test harness

API Response Format Fixes:
- Changed RiskContractReference.Success from string to bool (matches actual API)
- Updated GetRiskContractReference and UpdateRiskContractReference mock JSON files
- Fixed unit test assertions to check boolean values

Integration Test Harness:
- Added integration_test_helper.go with IntegrationTestClient, LogResponse, and TestRawAPIResponse
- Created risk_contracts_integration_test.go with tests for risk contract endpoints
- Added run-integration-tests.sh script for easy test execution
- Documented in INTEGRATION_TESTS.md and INTEGRATION_TEST_EXAMPLE.md
- Updated README.md with integration testing section
- Helper supports both ATHENA_CLIENT_ID/SECRET and ATHENA_API_KEY/SECRET env vars

All unit tests pass. Integration tests validated actual API response formats.
