### PR TITLE
fix: CreateRiskContract and DeleteRiskContract success field should be integer

### DIFF
--- a/athenahealth/generic.go
+++ b/athenahealth/generic.go
@@ -9,3 +9,9 @@ type ErrorMessageResponse struct {
 	Message string `json:"errormessage"`
 	Success bool   `json:"success"`
 }
+
+// IntegerSuccessResponse is used for endpoints that return success as an integer
+type IntegerSuccessResponse struct {
+	Errors  []map[string]interface{} `json:"errors,omitempty"`
+	Success int                      `json:"success"`
+}

--- a/athenahealth/resources/CreateRiskContract.json
+++ b/athenahealth/resources/CreateRiskContract.json
@@ -1,3 +1,3 @@
 {
-  "success": true
+  "success": 1
 }

--- a/athenahealth/resources/DeleteRiskContract.json
+++ b/athenahealth/resources/DeleteRiskContract.json
@@ -1,3 +1,3 @@
 {
-  "success": true
+  "success": 1
 }

--- a/athenahealth/risk_contracts.go
+++ b/athenahealth/risk_contracts.go
@@ -70,7 +70,7 @@ func (h *HTTPClient) CreateRiskContract(ctx context.Context, patientID string, o
 		panic("opts is nil")
 	}
 
-	out := &MessageResponse{}
+	out := &IntegerSuccessResponse{}
 
 	form := url.Values{}
 	form.Add("riskcontractid", strconv.Itoa(opts.RiskContractID))
@@ -109,7 +109,7 @@ type DeleteRiskContractOptions struct {
 //
 // https://docs.athenahealth.com/api/api-ref/patient-risk-contract
 func (h *HTTPClient) DeleteRiskContract(ctx context.Context, patientID string, riskContractID int, opts *DeleteRiskContractOptions) error {
-	out := &MessageResponse{}
+	out := &IntegerSuccessResponse{}
 
 	path := fmt.Sprintf("/chart/%s/riskcontract/%d", patientID, riskContractID)
 


### PR DESCRIPTION
## fix: CreateRiskContract and DeleteRiskContract success field should be integer

- API returns success as integer (0 or 1), not boolean
- Created IntegerSuccessResponse type for endpoints with integer success
- Updated CreateRiskContract and DeleteRiskContract to use IntegerSuccessResponse
- Updated mock JSON files to use integer values
- Matches athenahealth API documentation for patient risk contract endpoints

Fixes marshaling error when API returns numeric success field.
