### PR TITLE
Add AddOrderActionNote support (CLN-628)

### DIFF
--- a/athenahealth/client.go
+++ b/athenahealth/client.go
@@ -144,6 +144,7 @@ type Client interface {
 	GetOrderSubscription(ctx context.Context) (*Subscription, error)
 	SubscribeOrders(ctx context.Context, opts *SubscribeOrdersOptions) error
 	UnsubscribeOrders(ctx context.Context, opts *SubscribeOrdersOptions) error
+	AddOrderActionNote(ctx context.Context, orderID int, opts *AddOrderActionNoteOptions) (*AddOrderActionNoteResult, error)
 
 	// Prescriptions
 	UpdatePrescription(ctx context.Context, departmentID int, patientID int, documentID int, opts *UpdatePrescriptionOptions) (*UpdatePrescriptionResult, error)

--- a/athenahealth/orders.go
+++ b/athenahealth/orders.go
@@ -2,6 +2,7 @@ package athenahealth
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -303,4 +304,36 @@ func (h *HTTPClient) UnsubscribeOrders(ctx context.Context, opts *SubscribeOrder
 
 	_, err := h.DeleteForm(ctx, "/orders/changed/subscription", form, nil)
 	return err
+}
+
+// AddOrderActionNoteOptions contains the options for AddOrderActionNote.
+type AddOrderActionNoteOptions struct {
+	ActionNote string
+}
+
+// AddOrderActionNoteResult is the response from AddOrderActionNote.
+type AddOrderActionNoteResult struct {
+	ErrorMessage  *string `json:"errormessage,omitempty"`
+	NewDocumentID *string `json:"newdocumentid,omitempty"`
+	Success       string  `json:"success"`
+	VersionToken  *string `json:"versiontoken,omitempty"`
+}
+
+// AddOrderActionNote adds an action note to an order document.
+//
+// POST /v1/{practiceid}/documents/order/{orderid}/actions
+//
+// https://docs.athenahealth.com/api/api-ref/document-type-order#Add-action-note-to-order
+func (h *HTTPClient) AddOrderActionNote(ctx context.Context, orderID int, opts *AddOrderActionNoteOptions) (*AddOrderActionNoteResult, error) {
+	form := url.Values{}
+	if opts != nil {
+		form.Add("actionnote", opts.ActionNote)
+	}
+
+	out := &AddOrderActionNoteResult{}
+	if _, err := h.PostForm(ctx, fmt.Sprintf("/documents/order/%d/actions", orderID), form, out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }

--- a/athenahealth/orders_integration_test.go
+++ b/athenahealth/orders_integration_test.go
@@ -2,6 +2,7 @@ package athenahealth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -115,4 +116,42 @@ func TestIntegration_GetSignedOffOrderSubscription(t *testing.T) {
 	}
 
 	LogResponse(t, "GetSignedOffOrderSubscription Result", result)
+}
+
+func TestIntegration_AddOrderActionNote_RawResponse(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	orderID := mustGetEnvInt(t, "ATHENA_TEST_ORDER_ID", true)
+	if orderID == 0 {
+		t.Skip("ATHENA_TEST_ORDER_ID not set, skipping")
+	}
+
+	t.Logf("Testing POST /documents/order/%d/actions", orderID)
+
+	params := url.Values{}
+	params.Add("actionnote", "Integration test action note")
+
+	TestRawAPIResponse(t, client, http.MethodPost, fmt.Sprintf("/documents/order/%d/actions", orderID), params)
+}
+
+func TestIntegration_AddOrderActionNote(t *testing.T) {
+	client := IntegrationTestClient(t)
+
+	orderID := mustGetEnvInt(t, "ATHENA_TEST_ORDER_ID", true)
+	if orderID == 0 {
+		t.Skip("ATHENA_TEST_ORDER_ID not set, skipping")
+	}
+
+	ctx := context.Background()
+	opts := &AddOrderActionNoteOptions{
+		ActionNote: "Integration test action note",
+	}
+
+	result, err := client.AddOrderActionNote(ctx, orderID, opts)
+	if err != nil {
+		t.Fatalf("AddOrderActionNote failed: %v", err)
+	}
+
+	LogResponse(t, "AddOrderActionNote Result", result)
+	t.Logf("Success: %s", result.Success)
 }

--- a/athenahealth/orders_test.go
+++ b/athenahealth/orders_test.go
@@ -195,3 +195,63 @@ func TestHTTPClient_UnsubscribeOrders(t *testing.T) {
 	assert.NoError(err)
 	assert.True(called)
 }
+
+func TestHTTPClient_AddOrderActionNote(t *testing.T) {
+	assert := assert.New(t)
+
+	orderID := 12345
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/documents/order/12345/actions", r.URL.Path)
+
+		assert.NoError(r.ParseForm())
+		assert.Equal("Test action note", r.Form.Get("actionnote"))
+
+		b, _ := os.ReadFile("./resources/AddOrderActionNote.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	opts := &AddOrderActionNoteOptions{
+		ActionNote: "Test action note",
+	}
+
+	result, err := athenaClient.AddOrderActionNote(context.Background(), orderID, opts)
+
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.Equal("true", result.Success)
+	assert.NotNil(result.NewDocumentID)
+	assert.Equal("98765", *result.NewDocumentID)
+	assert.NotNil(result.VersionToken)
+	assert.Equal("abc123token", *result.VersionToken)
+}
+
+func TestHTTPClient_AddOrderActionNote_NilOpts(t *testing.T) {
+	assert := assert.New(t)
+
+	orderID := 12345
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/documents/order/12345/actions", r.URL.Path)
+
+		assert.NoError(r.ParseForm())
+		assert.Empty(r.Form.Get("actionnote"))
+
+		b, _ := os.ReadFile("./resources/AddOrderActionNote.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	result, err := athenaClient.AddOrderActionNote(context.Background(), orderID, nil)
+
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.Equal("true", result.Success)
+}

--- a/athenahealth/resources/AddOrderActionNote.json
+++ b/athenahealth/resources/AddOrderActionNote.json
@@ -1,0 +1,5 @@
+{
+  "success": "true",
+  "newdocumentid": "98765",
+  "versiontoken": "abc123token"
+}


### PR DESCRIPTION
## Summary

- Adds `AddOrderActionNote` to the `Client` interface and `HTTPClient` implementation (`POST /v1/{practiceid}/documents/order/{orderid}/actions`)
- Adds `AddOrderActionNoteOptions` and `AddOrderActionNoteResult` types
- Adds unit tests covering the happy path and nil-opts case
- Adds integration tests gated on `ATHENA_TEST_ORDER_ID` env var
- Adds `resources/AddOrderActionNote.json` fixture

Tracks: [CLN-628](https://linear.app/harbor-health/issue/CLN-628)

## Test plan

- [ ] `go test ./athenahealth/... -run TestHTTPClient_AddOrderActionNote` passes
- [ ] Integration tests run against a sandbox with `ATHENA_TEST_ORDER_ID` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)