### PR TITLE
Fix AddOrderActionNoteResult.Success type to bool (CLN-628)

### DIFF
--- a/athenahealth/orders.go
+++ b/athenahealth/orders.go
@@ -315,7 +315,7 @@ type AddOrderActionNoteOptions struct {
 type AddOrderActionNoteResult struct {
 	ErrorMessage  *string `json:"errormessage,omitempty"`
 	NewDocumentID *string `json:"newdocumentid,omitempty"`
-	Success       string  `json:"success"`
+	Success       bool    `json:"success"`
 	VersionToken  *string `json:"versiontoken,omitempty"`
 }
 

--- a/athenahealth/orders_integration_test.go
+++ b/athenahealth/orders_integration_test.go
@@ -153,5 +153,5 @@ func TestIntegration_AddOrderActionNote(t *testing.T) {
 	}
 
 	LogResponse(t, "AddOrderActionNote Result", result)
-	t.Logf("Success: %s", result.Success)
+	t.Logf("Success: %v", result.Success)
 }

--- a/athenahealth/orders_test.go
+++ b/athenahealth/orders_test.go
@@ -223,7 +223,7 @@ func TestHTTPClient_AddOrderActionNote(t *testing.T) {
 
 	assert.NoError(err)
 	assert.NotNil(result)
-	assert.Equal("true", result.Success)
+	assert.Equal(true, result.Success)
 	assert.NotNil(result.NewDocumentID)
 	assert.Equal("98765", *result.NewDocumentID)
 	assert.NotNil(result.VersionToken)
@@ -253,5 +253,5 @@ func TestHTTPClient_AddOrderActionNote_NilOpts(t *testing.T) {
 
 	assert.NoError(err)
 	assert.NotNil(result)
-	assert.Equal("true", result.Success)
+	assert.Equal(true, result.Success)
 }

--- a/athenahealth/resources/AddOrderActionNote.json
+++ b/athenahealth/resources/AddOrderActionNote.json
@@ -1,5 +1,5 @@
 {
-  "success": "true",
+  "success": true,
   "newdocumentid": "98765",
   "versiontoken": "abc123token"
 }


### PR DESCRIPTION
## Summary

- Fixes `AddOrderActionNoteResult.Success` from `string` to `bool` — the API returns `true`/`false`, not `"true"`/`"false"`
- Updates the JSON fixture, unit tests, and integration test log line accordingly

## Test plan

- [ ] `go test ./athenahealth/... -run TestHTTPClient_AddOrderActionNote` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)