### PR TITLE
Fix signed-off orders URL paths

### DIFF
--- a/athenahealth/orders.go
+++ b/athenahealth/orders.go
@@ -58,7 +58,7 @@ type ListChangedSignedOffOrdersResult struct {
 
 // ListChangedSignedOffOrders - Get signed-off orders based on subscribed change events
 //
-// GET /v1/{practiceid}/orders/signedoff/changed
+// GET /v1/{practiceid}/orders/signedoff
 //
 // https://docs.athenahealth.com/api/api-ref/document-type-order#Get-signed-off-orders
 func (h *HTTPClient) ListChangedSignedOffOrders(ctx context.Context, opts *ListChangedSignedOffOrdersOptions) (*ListChangedSignedOffOrdersResult, error) {
@@ -92,7 +92,7 @@ func (h *HTTPClient) ListChangedSignedOffOrders(ctx context.Context, opts *ListC
 
 	out := &listChangedSignedOffOrdersResponse{}
 
-	_, err := h.Get(ctx, "/orders/signedoff/changed", q, out)
+	_, err := h.Get(ctx, "/orders/signedoff", q, out)
 	if err != nil {
 		return nil, err
 	}
@@ -105,13 +105,13 @@ func (h *HTTPClient) ListChangedSignedOffOrders(ctx context.Context, opts *ListC
 
 // GetSignedOffOrderSubscription - Get list of signed-off order change subscriptions
 //
-// GET /v1/{practiceid}/orders/signedoff/changed/subscription
+// GET /v1/{practiceid}/orders/signedoff/subscription
 //
 // https://docs.athenahealth.com/api/api-ref/document-type-order#Get-list-of-signed-off-order-change-subscription(s)
 func (h *HTTPClient) GetSignedOffOrderSubscription(ctx context.Context) (*Subscription, error) {
 	out := &Subscription{}
 
-	_, err := h.Get(ctx, "/orders/signedoff/changed/subscription", nil, out)
+	_, err := h.Get(ctx, "/orders/signedoff/subscription", nil, out)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ type SubscribeSignedOffOrdersOptions struct {
 
 // SubscribeSignedOffOrders - Subscribe to all/specific change events for signed-off orders
 //
-// POST /v1/{practiceid}/orders/signedoff/changed/subscription
+// POST /v1/{practiceid}/orders/signedoff/subscription
 //
 // https://docs.athenahealth.com/api/api-ref/document-type-order#Subscribe-to-all/specific-change-events-for-signed-off-orders
 func (h *HTTPClient) SubscribeSignedOffOrders(ctx context.Context, opts *SubscribeSignedOffOrdersOptions) error {
@@ -136,13 +136,13 @@ func (h *HTTPClient) SubscribeSignedOffOrders(ctx context.Context, opts *Subscri
 		form.Add("eventname", opts.EventName)
 	}
 
-	_, err := h.PostForm(ctx, "/orders/signedoff/changed/subscription", form, nil)
+	_, err := h.PostForm(ctx, "/orders/signedoff/subscription", form, nil)
 	return err
 }
 
 // UnsubscribeSignedOffOrders - Unsubscribe from all/specific change events for signed-off orders
 //
-// DELETE /v1/{practiceid}/orders/signedoff/changed/subscription
+// DELETE /v1/{practiceid}/orders/signedoff/subscription
 //
 // https://docs.athenahealth.com/api/api-ref/document-type-order#Subscribe-to-all/specific-change-events-for-signed-off-orders
 func (h *HTTPClient) UnsubscribeSignedOffOrders(ctx context.Context, opts *SubscribeSignedOffOrdersOptions) error {
@@ -153,7 +153,7 @@ func (h *HTTPClient) UnsubscribeSignedOffOrders(ctx context.Context, opts *Subsc
 		form.Add("eventname", opts.EventName)
 	}
 
-	_, err := h.DeleteForm(ctx, "/orders/signedoff/changed/subscription", form, nil)
+	_, err := h.DeleteForm(ctx, "/orders/signedoff/subscription", form, nil)
 	return err
 }
 

--- a/athenahealth/orders_integration_test.go
+++ b/athenahealth/orders_integration_test.go
@@ -72,12 +72,12 @@ func TestIntegration_GetOrderSubscription(t *testing.T) {
 func TestIntegration_ListChangedSignedOffOrders_RawResponse(t *testing.T) {
 	client := IntegrationTestClient(t)
 
-	t.Log("Testing GET /orders/signedoff/changed")
+	t.Log("Testing GET /orders/signedoff")
 
 	params := url.Values{}
 	params.Add("leaveunprocessed", "true")
 
-	TestRawAPIResponse(t, client, http.MethodGet, "/orders/signedoff/changed", params)
+	TestRawAPIResponse(t, client, http.MethodGet, "/orders/signedoff", params)
 }
 
 func TestIntegration_ListChangedSignedOffOrders(t *testing.T) {
@@ -100,9 +100,9 @@ func TestIntegration_ListChangedSignedOffOrders(t *testing.T) {
 func TestIntegration_GetSignedOffOrderSubscription_RawResponse(t *testing.T) {
 	client := IntegrationTestClient(t)
 
-	t.Log("Testing GET /orders/signedoff/changed/subscription")
+	t.Log("Testing GET /orders/signedoff/subscription")
 
-	TestRawAPIResponse(t, client, http.MethodGet, "/orders/signedoff/changed/subscription", nil)
+	TestRawAPIResponse(t, client, http.MethodGet, "/orders/signedoff/subscription", nil)
 }
 
 func TestIntegration_GetSignedOffOrderSubscription(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix `ListChangedSignedOffOrders` to call `/orders/signedoff` instead of `/orders/signedoff/changed`
- Fix signed-off order subscription endpoints (Get/Subscribe/Unsubscribe) to use `/orders/signedoff/subscription` instead of `/orders/signedoff/changed/subscription`
- Update integration test path references to match

## Test plan
- [x] `go build ./...`
- [x] `go test ./athenahealth/ -run "SignedOff|Order"`
- [ ] Verify against athenahealth API in integration env

🤖 Generated with [Claude Code](https://claude.com/claude-code)