### PR TITLE
Add PreviousPatientIDs field and ShowPreviousPatientIDs option to ListChangedPatients

### DIFF
--- a/athenahealth/patients.go
+++ b/athenahealth/patients.go
@@ -124,6 +124,7 @@ type Patient struct {
 	OccupationCode                     string             `json:"occupationcode"`
 	OnlineStatementOnly                bool               `json:"onlinestatementonly"`
 	PatientID                          string             `json:"patientid"`
+	PreviousPatientIDs                 []string           `json:"previouspatientids"`
 	PatientPhoto                       bool               `json:"patientphoto"`
 	PatientPhotoURL                    string             `json:"patientphotourl"`
 	PortalAccessGiven                  bool               `json:"portalaccessgiven"`
@@ -687,6 +688,7 @@ type ListChangedPatientOptions struct {
 	LeaveUnprocessed           bool
 	PatientID                  string
 	ReturnGlobalID             bool
+	ShowPreviousPatientIDs     bool
 	ShowProcessedEndDatetime   time.Time
 	ShowProcessedStartDatetime time.Time
 }
@@ -724,6 +726,10 @@ func (h *HTTPClient) ListChangedPatients(ctx context.Context, opts *ListChangedP
 
 		if opts.ReturnGlobalID {
 			q.Add("returnglobalid", strconv.FormatBool(opts.ReturnGlobalID))
+		}
+
+		if opts.ShowPreviousPatientIDs {
+			q.Add("showpreviouspatientids", "true")
 		}
 
 		if !opts.ShowProcessedEndDatetime.IsZero() {


### PR DESCRIPTION
## Summary

Required by harbor-manifold CX-792 (patients handler for the listener lambda).

Changes:
- `Patient` struct: adds `PreviousPatientIDs []string` mapped to `json:"previouspatientids"`. Athena omits this field on non-merge records and returns a string array on merge records (e.g. `["73259"]`).
- `ListChangedPatientOptions`: adds `ShowPreviousPatientIDs bool`, which maps to the `showpreviouspatientids` query parameter on `GET /patients/changed`.

Verified against sandbox practice `2829201` — a manual chart merge confirmed the field is present on the surviving chart and absent on all other records.