### PR TITLE
Add FlexBool to tolerate documentationonly as bool or string

### DIFF
--- a/athenahealth/orders.go
+++ b/athenahealth/orders.go
@@ -9,29 +9,29 @@ import (
 )
 
 type SignedOffOrder struct {
-	AdministerYN                  *string `json:"administeryn"`
-	ApprovedBy                    *string `json:"approvedby"`
-	ApprovedTimestamp             *string `json:"approvedtimestamp"`
-	AssignedUser                  *string `json:"assigneduser"`
-	Class                         *string `json:"class"`
-	ClassDescription              *string `json:"classdescription"`
-	ClinicalOrderTypeID           *int    `json:"clinicalordertypeid"`
-	ClinicalProviderOrderTypeID   *int    `json:"clinicalproviderordertypeid"`
-	DateOrdered                   *string `json:"dateordered"`
-	DeniedBy                      *string `json:"deniedby"`
-	DeniedTimestamp               *string `json:"deniedtimestamp"`
-	DepartmentID                  *int    `json:"departmentid"`
-	Description                   *string `json:"description"`
-	DocumentationOnly             *string `json:"documentationonly"`
-	DocumentID                    *int    `json:"documentid"`
-	EncounterID                   *int    `json:"encounterid"`
-	ExternalNote                  *string `json:"externalnote"`
-	LocalPatientID                *int    `json:"localpatientid"`
-	OrderGenusName                *string `json:"ordergenusname"`
-	OrderingProvider              *string `json:"orderingprovider"`
-	OutOfNetworkReason            *string `json:"outofnetworkreason"`
-	PatientID                     *int    `json:"patientid"`
-	Status                        *string `json:"status"`
+	AdministerYN                *string   `json:"administeryn"`
+	ApprovedBy                  *string   `json:"approvedby"`
+	ApprovedTimestamp           *string   `json:"approvedtimestamp"`
+	AssignedUser                *string   `json:"assigneduser"`
+	Class                       *string   `json:"class"`
+	ClassDescription            *string   `json:"classdescription"`
+	ClinicalOrderTypeID         *int      `json:"clinicalordertypeid"`
+	ClinicalProviderOrderTypeID *int      `json:"clinicalproviderordertypeid"`
+	DateOrdered                 *string   `json:"dateordered"`
+	DeniedBy                    *string   `json:"deniedby"`
+	DeniedTimestamp             *string   `json:"deniedtimestamp"`
+	DepartmentID                *int      `json:"departmentid"`
+	Description                 *string   `json:"description"`
+	DocumentationOnly           *FlexBool `json:"documentationonly"`
+	DocumentID                  *int      `json:"documentid"`
+	EncounterID                 *int      `json:"encounterid"`
+	ExternalNote                *string   `json:"externalnote"`
+	LocalPatientID              *int      `json:"localpatientid"`
+	OrderGenusName              *string   `json:"ordergenusname"`
+	OrderingProvider            *string   `json:"orderingprovider"`
+	OutOfNetworkReason          *string   `json:"outofnetworkreason"`
+	PatientID                   *int      `json:"patientid"`
+	Status                      *string   `json:"status"`
 }
 
 type ListChangedSignedOffOrdersOptions struct {
@@ -158,29 +158,29 @@ func (h *HTTPClient) UnsubscribeSignedOffOrders(ctx context.Context, opts *Subsc
 }
 
 type ChangedOrder struct {
-	AdministerYN                *string `json:"administeryn"`
-	ApprovedBy                  *string `json:"approvedby"`
-	ApprovedTimestamp           *string `json:"approvedtimestamp"`
-	AssignedUser                *string `json:"assigneduser"`
-	Class                       *string `json:"class"`
-	ClassDescription            *string `json:"classdescription"`
-	ClinicalOrderTypeID         *int    `json:"clinicalordertypeid"`
-	ClinicalProviderOrderTypeID *int    `json:"clinicalproviderordertypeid"`
-	DateOrdered                 *string `json:"dateordered"`
-	DeniedBy                    *string `json:"deniedby"`
-	DeniedTimestamp             *string `json:"deniedtimestamp"`
-	DepartmentID                *int    `json:"departmentid"`
-	Description                 *string `json:"description"`
-	DocumentationOnly           *string `json:"documentationonly"`
-	DocumentID                  *int    `json:"documentid"`
-	EncounterID                 *int    `json:"encounterid"`
-	ExternalNote                *string `json:"externalnote"`
-	LocalPatientID              *int    `json:"localpatientid"`
-	OrderGenusName              *string `json:"ordergenusname"`
-	OrderingProvider            *string `json:"orderingprovider"`
-	OutOfNetworkReason          *string `json:"outofnetworkreason"`
-	PatientID                   *int    `json:"patientid"`
-	Status                      *string `json:"status"`
+	AdministerYN                *string   `json:"administeryn"`
+	ApprovedBy                  *string   `json:"approvedby"`
+	ApprovedTimestamp           *string   `json:"approvedtimestamp"`
+	AssignedUser                *string   `json:"assigneduser"`
+	Class                       *string   `json:"class"`
+	ClassDescription            *string   `json:"classdescription"`
+	ClinicalOrderTypeID         *int      `json:"clinicalordertypeid"`
+	ClinicalProviderOrderTypeID *int      `json:"clinicalproviderordertypeid"`
+	DateOrdered                 *string   `json:"dateordered"`
+	DeniedBy                    *string   `json:"deniedby"`
+	DeniedTimestamp             *string   `json:"deniedtimestamp"`
+	DepartmentID                *int      `json:"departmentid"`
+	Description                 *string   `json:"description"`
+	DocumentationOnly           *FlexBool `json:"documentationonly"`
+	DocumentID                  *int      `json:"documentid"`
+	EncounterID                 *int      `json:"encounterid"`
+	ExternalNote                *string   `json:"externalnote"`
+	LocalPatientID              *int      `json:"localpatientid"`
+	OrderGenusName              *string   `json:"ordergenusname"`
+	OrderingProvider            *string   `json:"orderingprovider"`
+	OutOfNetworkReason          *string   `json:"outofnetworkreason"`
+	PatientID                   *int      `json:"patientid"`
+	Status                      *string   `json:"status"`
 }
 
 type ListChangedOrdersOptions struct {

--- a/athenahealth/orders_test.go
+++ b/athenahealth/orders_test.go
@@ -32,6 +32,9 @@ func TestHTTPClient_ListChangedSignedOffOrders(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(res.Orders, 2)
 	assert.Equal(2, res.Pagination.TotalCount)
+	// athenahealth returns documentationonly as either an empty string or a bool.
+	assert.Equal(FlexBool(false), *res.Orders[0].DocumentationOnly)
+	assert.Equal(FlexBool(false), *res.Orders[1].DocumentationOnly)
 }
 
 func TestHTTPClient_GetSignedOffOrderSubscription(t *testing.T) {
@@ -125,6 +128,9 @@ func TestHTTPClient_ListChangedOrders(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(res.Orders, 2)
 	assert.Equal(2, res.Pagination.TotalCount)
+	// athenahealth returns documentationonly as either an empty string or a bool.
+	assert.Equal(FlexBool(false), *res.Orders[0].DocumentationOnly)
+	assert.Equal(FlexBool(true), *res.Orders[1].DocumentationOnly)
 }
 
 func TestHTTPClient_GetOrderSubscription(t *testing.T) {

--- a/athenahealth/resources/ListChangedOrders.json
+++ b/athenahealth/resources/ListChangedOrders.json
@@ -40,7 +40,7 @@
       "deniedtimestamp": null,
       "departmentid": 2,
       "description": "Chest X-Ray",
-      "documentationonly": "",
+      "documentationonly": true,
       "documentid": 5002,
       "encounterid": 101,
       "externalnote": "Priority imaging needed",

--- a/athenahealth/resources/ListChangedSignedOffOrders.json
+++ b/athenahealth/resources/ListChangedSignedOffOrders.json
@@ -40,7 +40,7 @@
       "deniedtimestamp": null,
       "departmentid": 2,
       "description": "Chest X-Ray",
-      "documentationonly": "",
+      "documentationonly": false,
       "documentid": 5002,
       "encounterid": 101,
       "externalnote": "Priority imaging needed",

--- a/athenahealth/types.go
+++ b/athenahealth/types.go
@@ -6,6 +6,43 @@ import (
 	"strconv"
 )
 
+// FlexBool is a boolean that tolerates athenahealth returning the same field as
+// either a JSON bool (true/false) or a string ("", "true", "false"). athenahealth
+// is inconsistent about this for fields like "documentationonly", so a plain bool
+// or string fails to unmarshal half the responses. An empty or null value is
+// treated as false.
+type FlexBool bool
+
+func (b *FlexBool) UnmarshalJSON(data []byte) error {
+	var aux interface{}
+
+	err := json.Unmarshal(data, &aux)
+	if err != nil {
+		return err
+	}
+
+	switch v := aux.(type) {
+	case bool:
+		*b = FlexBool(v)
+	case string:
+		if v == "" {
+			*b = false
+			return nil
+		}
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("cannot parse %q as bool: %w", v, err)
+		}
+		*b = FlexBool(parsed)
+	case nil:
+		*b = false
+	default:
+		return fmt.Errorf("unknown type: %T", v)
+	}
+
+	return nil
+}
+
 type NumberString string
 
 func (n *NumberString) UnmarshalJSON(data []byte) error {

--- a/athenahealth/types_test.go
+++ b/athenahealth/types_test.go
@@ -2,6 +2,72 @@ package athenahealth
 
 import "testing"
 
+func TestFlexBool_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    FlexBool
+		wantErr bool
+	}{
+		{
+			name: "bool true",
+			args: args{data: []byte(`true`)},
+			want: true,
+		},
+		{
+			name: "bool false",
+			args: args{data: []byte(`false`)},
+			want: false,
+		},
+		{
+			name: "empty string",
+			args: args{data: []byte(`""`)},
+			want: false,
+		},
+		{
+			name: "string true",
+			args: args{data: []byte(`"true"`)},
+			want: true,
+		},
+		{
+			name: "string false",
+			args: args{data: []byte(`"false"`)},
+			want: false,
+		},
+		{
+			name: "null",
+			args: args{data: []byte(`null`)},
+			want: false,
+		},
+		{
+			name:    "non-bool string",
+			args:    args{data: []byte(`"maybe"`)},
+			wantErr: true,
+		},
+		{
+			name:    "number value",
+			args:    args{data: []byte(`1`)},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := new(FlexBool)
+			err := b.UnmarshalJSON(tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FlexBool.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && *b != tt.want {
+				t.Errorf("FlexBool.UnmarshalJSON() = %v, want %v", *b, tt.want)
+			}
+		})
+	}
+}
+
 func TestNumberString_UnmarshalJSON(t *testing.T) {
 	type args struct {
 		data []byte


### PR DESCRIPTION
## Problem

The manifold athena listener intermittently failed when polling athenahealth for changed orders:

```
json: cannot unmarshal bool into Go struct field ChangedOrder.orders.documentationonly of type string
```

athenahealth returns the orders `documentationonly` field inconsistently — sometimes a JSON bool (`true`/`false`), sometimes an empty string (`""`). The field was typed `*string` on `SignedOffOrder` and `ChangedOrder`, so any response with a boolean value failed to unmarshal and the entire `ListChangedOrders` call errored. (`prescriptions.go` already types it as `bool`, so a plain switch to `*bool` would instead break on the empty-string responses.)

## Change

- New `FlexBool` type in `types.go` with a custom `UnmarshalJSON` accepting bool, string (`""`/`"true"`/`"false"`), and `null` (empty/null → `false`), following the existing `NumberString` pattern.
- Retype `DocumentationOnly` to `*FlexBool` on both order structs.
- Fixtures now exercise both shapes (one `""`, one bool).
- Added `TestFlexBool_UnmarshalJSON` plus `DocumentationOnly` assertions on the list-orders tests.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Follow-up

After this merges and a release is cut, manifold bumps the dependency and deploys (CLN-835).

Linear: CLN-834 (parent CLN-833)

🤖 Generated with [Claude Code](https://claude.com/claude-code)