### PR TITLE
Sync internal with main (bring in patients-feed field)

### DIFF
--- a/athenahealth/patients.go
+++ b/athenahealth/patients.go
@@ -124,6 +124,7 @@ type Patient struct {
 	OccupationCode                     string             `json:"occupationcode"`
 	OnlineStatementOnly                bool               `json:"onlinestatementonly"`
 	PatientID                          string             `json:"patientid"`
+	PreviousPatientIDs                 []string           `json:"previouspatientids"`
 	PatientPhoto                       bool               `json:"patientphoto"`
 	PatientPhotoURL                    string             `json:"patientphotourl"`
 	PortalAccessGiven                  bool               `json:"portalaccessgiven"`
@@ -687,6 +688,7 @@ type ListChangedPatientOptions struct {
 	LeaveUnprocessed           bool
 	PatientID                  string
 	ReturnGlobalID             bool
+	ShowPreviousPatientIDs     bool
 	ShowProcessedEndDatetime   time.Time
 	ShowProcessedStartDatetime time.Time
 }
@@ -724,6 +726,10 @@ func (h *HTTPClient) ListChangedPatients(ctx context.Context, opts *ListChangedP
 
 		if opts.ReturnGlobalID {
 			q.Add("returnglobalid", strconv.FormatBool(opts.ReturnGlobalID))
+		}
+
+		if opts.ShowPreviousPatientIDs {
+			q.Add("showpreviouspatientids", "true")
 		}
 
 		if !opts.ShowProcessedEndDatetime.IsZero() {


### PR DESCRIPTION
## Why

`internal` was missing one commit that lives on `main`: **#18 — Add `PreviousPatientIDs` field and `ShowPreviousPatientIDs` option to `ListChangedPatients`**. A release cut from `internal` (v0.0.20) therefore regressed the patients feed and broke the manifold build:

```
unknown field ShowPreviousPatientIDs in struct literal of type athenahealth.ListChangedPatientOptions
```

This merges `main` into `internal` so a release from `internal` carries **both** the `documentationonly` FlexBool fix (#19) and the patients-feed field (#18).

## Change

Merge commit only — brings `athenahealth/patients.go` (`PreviousPatientIDs` / `ShowPreviousPatientIDs`) onto `internal`. No conflicts. FlexBool changes from #19 are untouched.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass with both fixes present.

## Follow-up

Cut a new release tag (v0.0.21) from `internal` after merge; manifold then bumps to it (CLN-835).

Linear: CLN-835 (parent CLN-833)

🤖 Generated with [Claude Code](https://claude.com/claude-code)