### PR TITLE
ci(PLATENG-355): wire Datadog CI Visibility into Go tests

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -12,20 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: golangci-lint
         uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 # v9.3.0
         with:
           version: v2.12.2
-          args: --timeout=5m --tests=false
+          args: --timeout=5m
   test:
     name: unit tests
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: setup go
-        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.22'
       # harbor-github-actions is a private org repo that requires explicit access
@@ -34,23 +34,29 @@ jobs:
       # TODO: once Harbor-Engineering/harbor-github-actions grants access, replace
       # these steps with:
       #   uses: Harbor-Engineering/harbor-github-actions/harbor-health/actions/run-go-tests-and-publish@v1
+      # Note: the composite action also uploads JUnit XML artifacts and publishes a
+      # job summary via publish-test-summary — those steps are not inlined here.
       - name: Install gotestsum
+        if: github.event_name == 'pull_request'
         run: go install gotest.tools/gotestsum@v1.12.0
-      - name: Run tests
+      - name: Run tests (with CI Visibility)
+        if: github.event_name == 'push'
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_SERVICE: go-athenahealth
           DD_ENV: ci
           DD_VERSION: ${{ github.sha }}
+          DD_SITE: datadoghq.com
           DD_TAGS: "team:platform,layer:ehr-client"
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: "true"
+          DD_CIVISIBILITY_LOGS_ENABLED: "false"
         run: |
-          gobin="$(go env GOBIN)"
-          [[ -z "$gobin" ]] && gobin="$(go env GOPATH)/bin"
-          if [[ -n "$DD_API_KEY" ]]; then
-            export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
-            go install github.com/DataDog/orchestrion@v1.0.0
-            gotestsum --format testdox -- -toolexec "$gobin/orchestrion toolexec" -race ./...
-          else
-            echo "::notice::DD_API_KEY not set — running without CI Visibility (forked PR or secret not provisioned)"
-            gotestsum --format testdox -- -race ./...
+          if [[ -z "$DD_API_KEY" ]]; then
+            echo "::error::DD_API_KEY secret is not provisioned in this repo — see PLATENG-354"
+            exit 1
           fi
+          go install github.com/DataDog/orchestrion@v1.12.0
+          orchestrion go test -race ./...
+      - name: Run tests
+        if: github.event_name == 'pull_request'
+        run: gotestsum --format testdox -- -race ./...

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -38,7 +38,7 @@ jobs:
       # job summary via publish-test-summary — those steps are not inlined here.
       - name: Install gotestsum
         if: github.event_name == 'pull_request'
-        run: go install gotest.tools/gotestsum@v1.12.0
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run tests (with CI Visibility)
         if: github.event_name == 'push'
         env:
@@ -53,7 +53,7 @@ jobs:
         run: |
           if [[ -z "$DD_API_KEY" ]]; then
             echo "::notice::DD_API_KEY not provisioned — running without CI Visibility (see PLATENG-354)"
-            go install gotest.tools/gotestsum@v1.12.0
+            go install gotest.tools/gotestsum@v1.13.0
             gotestsum --format testdox -- -race ./...
           else
             go install github.com/DataDog/orchestrion@v1.12.0

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -24,8 +24,14 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: unit tests
+      - name: setup go
         uses: actions/setup-go@v2
         with:
           go-version: '1.22'
-      - run: go test ./...
+      - name: Run tests with CI Visibility
+        uses: Harbor-Engineering/harbor-github-actions/harbor-health/actions/run-go-tests-and-publish@v1
+        with:
+          enable-dd-trace: true
+          datadog-service: go-athenahealth
+          datadog-api-key: ${{ secrets.DD_API_KEY }}
+          datadog-extra-tags: 'team:platform layer:ehr-client'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -28,10 +28,25 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.22'
+      # harbor-github-actions is a private org repo that requires explicit access
+      # grants per consuming repo. Inlining the run-go-tests-and-publish action
+      # steps here until go-athenahealth is added to its allow-list.
+      # TODO: once Harbor-Engineering/harbor-github-actions grants access, replace
+      # these steps with:
+      #   uses: Harbor-Engineering/harbor-github-actions/harbor-health/actions/run-go-tests-and-publish@v1
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.0
+      - name: Install Orchestrion (dd-trace-go compile-time instrumentation)
+        run: go install github.com/DataDog/orchestrion@v1.0.0
       - name: Run tests with CI Visibility
-        uses: Harbor-Engineering/harbor-github-actions/harbor-health/actions/run-go-tests-and-publish@v1
-        with:
-          enable-dd-trace: true
-          datadog-service: go-athenahealth
-          datadog-api-key: ${{ secrets.DD_API_KEY }}
-          datadog-extra-tags: 'team:platform layer:ehr-client'
+        env:
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: "true"
+          DD_SERVICE: go-athenahealth
+          DD_ENV: ci
+          DD_VERSION: ${{ github.sha }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_TAGS: "team:platform,layer:ehr-client"
+        run: |
+          gobin="$(go env GOBIN)"
+          [[ -z "$gobin" ]] && gobin="$(go env GOPATH)/bin"
+          gotestsum --format testdox -- -toolexec "$gobin/orchestrion toolexec" -race ./...

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2
+        uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 # v9.3.0
         with:
           version: v2.12.2
           args: --timeout=5m --tests=false

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2
         with:
           version: latest
           args: --timeout=5m --tests=false
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
       - name: setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.22'
       # harbor-github-actions is a private org repo that requires explicit access
@@ -36,17 +36,21 @@ jobs:
       #   uses: Harbor-Engineering/harbor-github-actions/harbor-health/actions/run-go-tests-and-publish@v1
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.12.0
-      - name: Install Orchestrion (dd-trace-go compile-time instrumentation)
-        run: go install github.com/DataDog/orchestrion@v1.0.0
-      - name: Run tests with CI Visibility
+      - name: Run tests
         env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_CIVISIBILITY_AGENTLESS_ENABLED: "true"
           DD_SERVICE: go-athenahealth
           DD_ENV: ci
           DD_VERSION: ${{ github.sha }}
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_TAGS: "team:platform,layer:ehr-client"
         run: |
           gobin="$(go env GOBIN)"
           [[ -z "$gobin" ]] && gobin="$(go env GOPATH)/bin"
-          gotestsum --format testdox -- -toolexec "$gobin/orchestrion toolexec" -race ./...
+          if [[ -n "$DD_API_KEY" ]]; then
+            go install github.com/DataDog/orchestrion@v1.0.0
+            gotestsum --format testdox -- -toolexec "$gobin/orchestrion toolexec" -race ./...
+          else
+            echo "::notice::DD_API_KEY not set — running without CI Visibility (forked PR or secret not provisioned)"
+            gotestsum --format testdox -- -race ./...
+          fi

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.22'
+          go-version: '1.25'
       # harbor-github-actions is a private org repo that requires explicit access
       # grants per consuming repo. Inlining the run-go-tests-and-publish action
       # steps here until go-athenahealth is added to its allow-list.
@@ -52,11 +52,13 @@ jobs:
           DD_CIVISIBILITY_LOGS_ENABLED: "false"
         run: |
           if [[ -z "$DD_API_KEY" ]]; then
-            echo "::error::DD_API_KEY secret is not provisioned in this repo — see PLATENG-354"
-            exit 1
+            echo "::notice::DD_API_KEY not provisioned — running without CI Visibility (see PLATENG-354)"
+            go install gotest.tools/gotestsum@v1.12.0
+            gotestsum --format testdox -- -race ./...
+          else
+            go install github.com/DataDog/orchestrion@v1.12.0
+            orchestrion go test -race ./...
           fi
-          go install github.com/DataDog/orchestrion@v1.12.0
-          orchestrion go test -race ./...
       - name: Run tests
         if: github.event_name == 'pull_request'
         run: gotestsum --format testdox -- -race ./...

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2
         with:
-          version: latest
+          version: v2.12.2
           args: --timeout=5m --tests=false
   test:
     name: unit tests
@@ -39,7 +39,6 @@ jobs:
       - name: Run tests
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_CIVISIBILITY_AGENTLESS_ENABLED: "true"
           DD_SERVICE: go-athenahealth
           DD_ENV: ci
           DD_VERSION: ${{ github.sha }}
@@ -48,6 +47,7 @@ jobs:
           gobin="$(go env GOBIN)"
           [[ -z "$gobin" ]] && gobin="$(go env GOPATH)/bin"
           if [[ -n "$DD_API_KEY" ]]; then
+            export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
             go install github.com/DataDog/orchestrion@v1.0.0
             gotestsum --format testdox -- -toolexec "$gobin/orchestrion toolexec" -race ./...
           else

--- a/athenahealth/allergies_test.go
+++ b/athenahealth/allergies_test.go
@@ -18,7 +18,7 @@ func TestHTTPClient_SearchAllergies(t *testing.T) {
 		assert.Equal(searchVal, r.URL.Query().Get("searchvalue"))
 
 		b, _ := os.ReadFile("./resources/SearchAllergies.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -40,7 +40,7 @@ func TestHTTPClient_SearchAllergies_None(t *testing.T) {
 		assert.Equal(searchVal, r.URL.Query().Get("searchvalue"))
 
 		b := []byte("[]")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/appointment_checkin_checkout_test.go
+++ b/athenahealth/appointment_checkin_checkout_test.go
@@ -18,7 +18,7 @@ func TestHTTPClient_AppointmentCancelCheckIn(t *testing.T) {
 
 		assert.Equal(r.URL.Path, "/appointments/54/cancelcheckin")
 		b, _ := os.ReadFile("./resources/AppointmentCancelCheckIn.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -39,7 +39,7 @@ func TestHTTPClient_AppointmentCheckIn(t *testing.T) {
 
 		assert.Equal(r.URL.Path, "/appointments/54/checkin")
 		b, _ := os.ReadFile("./resources/AppointmentCheckIn.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -60,7 +60,7 @@ func TestHTTPClient_AppointmentStartCheckIn(t *testing.T) {
 
 		assert.Equal(r.URL.Path, "/appointments/54/startcheckin")
 		b, _ := os.ReadFile("./resources/AppointmentStartCheckIn.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/appointment_reminders_test.go
+++ b/athenahealth/appointment_reminders_test.go
@@ -39,7 +39,7 @@ func TestHTTPClient_ListAppointmentReminders(t *testing.T) {
 		assert.Equal("false", query.Get("showdeleted"))
 
 		b, _ := os.ReadFile("./resources/ListAppointmentReminders.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/appointment_slots_test.go
+++ b/athenahealth/appointment_slots_test.go
@@ -33,7 +33,7 @@ func TestHTTPClient_CreateAppointmentSlot(t *testing.T) {
 		assert.Equal(r.Form.Get("reasonid"), strconv.Itoa(*opts.ReasonID))
 		assert.Equal(r.URL.Path, "/appointments/open")
 		b, _ := os.ReadFile("./resources/CreateAppointmentSlot.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/appointment_types_test.go
+++ b/athenahealth/appointment_types_test.go
@@ -32,7 +32,7 @@ func TestHTTPClient_CreateAppointmentType(t *testing.T) {
 		assert.Equal(r.Form.Get("templatetypeonly"), strconv.FormatBool(*opts.TemplateTypeOnly))
 		assert.Equal(r.URL.Path, "/appointmenttypes")
 		b, _ := os.ReadFile("./resources/CreateAppointmentType.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/appointments_test.go
+++ b/athenahealth/appointments_test.go
@@ -19,7 +19,7 @@ func TestHTTPClient_GetAppointment(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/GetAppointment.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -36,7 +36,7 @@ func TestHTTPClient_ListAppointmentCustomFields(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/ListAppointmentCustomFields.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -58,7 +58,7 @@ func TestHTTPClient_ListBookedAppointments(t *testing.T) {
 		assert.Equal(AppointmentStatusCancelled.String(), r.URL.Query().Get("appointmentstatus"))
 
 		b, _ := os.ReadFile("./resources/ListBookedAppointments.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -89,7 +89,7 @@ func TestHTTPClient_ListChangedAppointments(t *testing.T) {
 		assert.Equal("06/02/2020 12:30:45", r.URL.Query().Get("showprocessedenddatetime"))
 
 		b, _ := os.ReadFile("./resources/ListChangedAppointments.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -141,7 +141,7 @@ func TestHTTPClient_ListAppointmentNotes(t *testing.T) {
 		assert.Equal("1", r.URL.Query().Get("appointmentid"))
 
 		b, _ := os.ReadFile("./resources/ListAppointmentNotes.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -248,7 +248,7 @@ func TestHTTPClient_ListOpenAppointmentSlots(t *testing.T) {
 		assert.Equal("7", r.URL.Query().Get("offset"))
 
 		b, _ := os.ReadFile("./resources/ListOpenAppointmentSlots.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -291,7 +291,7 @@ func TestHTTPClient_BookAppointment(t *testing.T) {
 		assert.Contains(string(reqBody), "urgent=true")
 
 		b, _ := os.ReadFile("./resources/BookAppointment.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -325,7 +325,7 @@ func TestHTTPClient_UpdateBookedAppointment_IntResponse(t *testing.T) {
 		assert.Equal(r.URL.Path, fmt.Sprintf("/appointments/booked/%s", apptID))
 
 		b, _ := os.ReadFile("./resources/UpdateBookedAppointment_IntResponse.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -358,7 +358,7 @@ func TestHTTPClient_UpdateBookedAppointment_StringResponse(t *testing.T) {
 		assert.Equal(r.URL.Path, fmt.Sprintf("/appointments/booked/%s", apptID))
 
 		b, _ := os.ReadFile("./resources/UpdateBookedAppointment_StringResponse.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -395,7 +395,7 @@ func TestHTTPClient_RescheduleAppointment(t *testing.T) {
 		assert.Equal(r.URL.Path, fmt.Sprintf("/appointments/%d/reschedule", 998877))
 
 		b, _ := os.ReadFile("./resources/RescheduleAppointment.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -483,7 +483,7 @@ func TestHTTPClient_FreezeAppointmentSlot(t *testing.T) {
 			assert.Equal(r.URL.Path, fmt.Sprintf("/appointments/%s/freeze", apptID))
 
 			b, _ := os.ReadFile(testCase.Resource)
-			w.Write(b)
+			_, _ = w.Write(b)
 		}
 
 		athenaClient, ts := testClient(h)

--- a/athenahealth/appointments_test.go
+++ b/athenahealth/appointments_test.go
@@ -113,7 +113,7 @@ func TestHTTPClient_CreateAppointmentNote(t *testing.T) {
 	called := false
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "notetext=test+note")
 
@@ -163,7 +163,7 @@ func TestHTTPClient_UpdateAppointmentNote(t *testing.T) {
 	called := false
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "notetext=test+note")
 		assert.Contains(string(reqBody), "noteid=2")
@@ -192,7 +192,7 @@ func TestHTTPClient_DeleteAppointmentNote(t *testing.T) {
 	called := false
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "noteid=1")
 
@@ -279,7 +279,7 @@ func TestHTTPClient_BookAppointment(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "appointmenttypeid=3")
 		assert.Contains(string(reqBody), "bookingnote=Hello+World%21")

--- a/athenahealth/charts_test.go
+++ b/athenahealth/charts_test.go
@@ -18,7 +18,7 @@ func TestHTTPClient_ListSocialHistoryTemplates(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/ListSocialHistoryTemplates.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -40,7 +40,7 @@ func TestHTTPClient_GetPatientSocialHistory(t *testing.T) {
 		assert.Equal("true", r.URL.Query().Get("showunansweredquestions"))
 
 		b, _ := os.ReadFile("./resources/GetPatientSocialHistory.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -74,7 +74,7 @@ func TestHTTPClient_UpdatePatientSocialHistory(t *testing.T) {
 	called := false
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "departmentid=2")
 		assert.Contains(string(reqBody), fmt.Sprintf("questions=%s", url.QueryEscape(string(questionBytes))))

--- a/athenahealth/claims_test.go
+++ b/athenahealth/claims_test.go
@@ -96,7 +96,7 @@ func TestHTTPClient_CreateClaim(t *testing.T) {
 		assert.Equal(r.Form.Get("supervisingproviderid"), opts.SupervisingProviderID)
 
 		b, _ := os.ReadFile("./resources/CreateClaim.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -136,7 +136,7 @@ func TestHTTPClient_ListClaims(t *testing.T) {
 		assert.Equal(r.URL.Query().Get("showcustomfields"), "true")
 
 		b, _ := os.ReadFile("./resources/ListClaims.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/customfields_test.go
+++ b/athenahealth/customfields_test.go
@@ -14,7 +14,7 @@ func TestHTTPClient_ListCustomFields(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/ListCustomFields.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/departments_test.go
+++ b/athenahealth/departments_test.go
@@ -20,7 +20,7 @@ func TestHTTPClient_DepartmentGetRequiredCheckInFields(t *testing.T) {
 
 		assert.Equal(r.URL.Path, "/departments/45/checkinrequired")
 		b, _ := os.ReadFile("./resources/DepartmentGetRequiredCheckInFields.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -37,7 +37,7 @@ func TestHTTPClient_GetDepartment(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/GetDepartment.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -58,7 +58,7 @@ func TestHTTPClient_ListDepartments(t *testing.T) {
 		assert.Equal("1", r.URL.Query().Get("showalldepartments"))
 
 		b, _ := os.ReadFile("./resources/ListDepartments.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/documents_test.go
+++ b/athenahealth/documents_test.go
@@ -20,7 +20,7 @@ func TestHTTPClient_ListAdminDocuments(t *testing.T) {
 		assert.Equal("3", r.URL.Query().Get("departmentid"))
 
 		b, _ := os.ReadFile("./resources/ListAdminDocuments.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -66,7 +66,7 @@ func TestHTTPClient_AddDocument(t *testing.T) {
 		assert.Equal(strconv.Itoa(providerID), r.FormValue("providerid"))
 
 		b, _ := os.ReadFile("./resources/AddDocument.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -110,7 +110,7 @@ func TestHTTPClient_AddDocumentReader(t *testing.T) {
 		assert.Equal(strconv.Itoa(apptID), r.FormValue("appointmentid"))
 
 		b, _ := os.ReadFile("./resources/AddDocument.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -159,7 +159,7 @@ func TestHTTPClient_AddClinicalDocument(t *testing.T) {
 		assert.Equal(strconv.Itoa(documentTypeId), r.FormValue("documenttypeid"))
 
 		b, _ := os.ReadFile("./resources/AddClinicalDocument.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -215,7 +215,7 @@ func TestHTTPClient_AddPatientCaseDocument(t *testing.T) {
 		assert.Equal("subject", r.FormValue("subject"))
 
 		b, _ := os.ReadFile("./resources/AddPatientCaseDocument.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -249,7 +249,7 @@ func TestHTTPClient_DeleteClinicalDocument(t *testing.T) {
 		assert.Contains(r.URL.Path, "/patients/123/documents/clinicaldocument/101")
 
 		b, _ := os.ReadFile("./resources/DeleteClinicalDocument.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -270,7 +270,7 @@ func TestHTTPClient_ListEncounterDocuments(t *testing.T) {
 		assert.Equal("3", r.URL.Query().Get("departmentid"))
 
 		b, _ := os.ReadFile("./resources/ListEncounterDocuments.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/encounter_test.go
+++ b/athenahealth/encounter_test.go
@@ -21,7 +21,7 @@ func TestHTTPClient_EncounterSummary(t *testing.T) {
 		assert.Equal("1", r.URL.Query().Get("mobile"))
 
 		b, _ := os.ReadFile("./resources/EncounterSummary.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/health_history_forms_test.go
+++ b/athenahealth/health_history_forms_test.go
@@ -22,7 +22,7 @@ func TestHTTPClient_GetHealthHistoryFormForAppointment(t *testing.T) {
 		assert.Equal(fmt.Sprintf("/appointments/%s/healthhistoryforms/%s", apptID, formID), r.URL.String())
 
 		b, _ := os.ReadFile("./resources/GetHealthHistoryFormForAppointment.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -55,7 +55,7 @@ func TestHTTPClient_UpdateHealthHistoryFormForAppointment(t *testing.T) {
 		assert.Equal(string(hhfRequestBytes), r.FormValue("healthhistoryform"))
 
 		b, _ := os.ReadFile("./resources/UpdateHealthHistoryFormForAppointmentResponse.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -200,7 +200,7 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 	if err != nil {
 		return res, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	var requestBodyLength int64
 	if srBody, ok := body.(*sizeRecordingReader); ok {
@@ -232,7 +232,7 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		return res, err
 	}
 	// close original req.Body before before overwriting
-	res.Body.Close()
+	_ = res.Body.Close()
 
 	res.Body = io.NopCloser(bytes.NewBuffer(resBody))
 

--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/eleanorhealth/go-athenahealth/athenahealth/ratelimiter"
@@ -160,14 +161,10 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 
 	h.requestLock.Unlock()
 
-	var requestBodyLength int64
+	var srBody *sizeRecordingReader
 	if body != nil {
-		data, err := io.ReadAll(body)
-		if err != nil {
-			return nil, err
-		}
-		requestBodyLength = int64(len(data))
-		body = bytes.NewReader(data)
+		srBody = newSizeRecordingReader(body)
+		body = srBody
 	}
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
 	if err != nil {
@@ -237,6 +234,11 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 
 	res.Body = io.NopCloser(bytes.NewBuffer(resBody))
 
+	var requestBodyLength int64
+	if srBody != nil {
+		requestBodyLength = srBody.size.Load()
+	}
+
 	h.logger.Info().
 		Str("method", method).
 		Str("url", reqURL).
@@ -275,6 +277,21 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 	}
 
 	return res, nil
+}
+
+type sizeRecordingReader struct {
+	r    io.Reader
+	size atomic.Int64
+}
+
+func newSizeRecordingReader(r io.Reader) *sizeRecordingReader {
+	return &sizeRecordingReader{r: r}
+}
+
+func (srr *sizeRecordingReader) Read(p []byte) (int, error) {
+	n, err := srr.r.Read(p)
+	srr.size.Add(int64(n))
+	return n, err
 }
 
 func (h *HTTPClient) WithLogger(logger *zerolog.Logger) *HTTPClient {

--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -160,8 +160,14 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 
 	h.requestLock.Unlock()
 
+	var requestBodyLength int64
 	if body != nil {
-		body = newSizeRecordingReader(body)
+		data, err := io.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
+		requestBodyLength = int64(len(data))
+		body = bytes.NewReader(data)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
 	if err != nil {
@@ -201,11 +207,6 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		return res, err
 	}
 	defer func() { _ = res.Body.Close() }()
-
-	var requestBodyLength int64
-	if srBody, ok := body.(*sizeRecordingReader); ok {
-		requestBodyLength = srBody.size
-	}
 
 	requestDuration := time.Since(requestStart)
 
@@ -274,24 +275,6 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 	}
 
 	return res, nil
-}
-
-type sizeRecordingReader struct {
-	r    io.Reader
-	size int64
-}
-
-func newSizeRecordingReader(r io.Reader) *sizeRecordingReader {
-	return &sizeRecordingReader{
-		r:    r,
-		size: 0,
-	}
-}
-
-func (srr *sizeRecordingReader) Read(p []byte) (int, error) {
-	n, err := srr.r.Read(p)
-	srr.size += int64(n)
-	return n, err
 }
 
 func (h *HTTPClient) WithLogger(logger *zerolog.Logger) *HTTPClient {

--- a/athenahealth/httpclient_test.go
+++ b/athenahealth/httpclient_test.go
@@ -33,7 +33,7 @@ func testClient(h http.HandlerFunc) (*HTTPClient, *httptest.Server) {
 		h = func(w http.ResponseWriter, r *http.Request) {
 			b, _ := json.Marshal(nil)
 			w.Header().Add("Content-Type", "application/json")
-			w.Write(b)
+			_, _ = w.Write(b)
 		}
 	}
 
@@ -170,7 +170,7 @@ func TestHTTPClient_request(t *testing.T) {
 		assert.Equal(fmt.Sprintf("Bearer %s", testToken), r.Header.Get("Authorization"))
 		assert.Equal(userAgent, r.UserAgent())
 
-		w.Write([]byte(`{"msg":"Hello World!"}`))
+		_, _ = w.Write([]byte(`{"msg":"Hello World!"}`))
 	}
 
 	athenaClient, ts := testClient(h)
@@ -377,7 +377,7 @@ func TestHTTPClient_Post(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodPost, r.Method)
 		b, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		_ = r.Body.Close()
 		assert.True(len(b) > 0)
 
 		called = true
@@ -400,7 +400,7 @@ func TestHTTPClient_PostForm(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodPost, r.Method)
 		b, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		_ = r.Body.Close()
 		assert.True(len(b) > 0)
 
 		assert.Equal("application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
@@ -428,7 +428,7 @@ func TestHTTPClient_PostFormReader(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodPost, r.Method)
 		b, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		_ = r.Body.Close()
 		assert.True(len(b) > 0)
 
 		assert.Equal("application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
@@ -494,7 +494,7 @@ func TestHTTPClient_Put(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodPut, r.Method)
 		b, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		_ = r.Body.Close()
 		assert.True(len(b) > 0)
 
 		called = true
@@ -517,7 +517,7 @@ func TestHTTPClient_PutForm(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodPut, r.Method)
 		b, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		_ = r.Body.Close()
 		assert.True(len(b) > 0)
 
 		assert.Equal("application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
@@ -545,7 +545,7 @@ func TestHTTPClient_Delete(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodDelete, r.Method)
 		b, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		_ = r.Body.Close()
 		assert.True(len(b) > 0)
 
 		called = true
@@ -570,7 +570,7 @@ func TestHTTPClient_DeleteForm(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodDelete, r.Method)
 		b, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		_ = r.Body.Close()
 		assert.True(len(b) > 0)
 
 		assert.Equal("application/x-www-form-urlencoded", r.Header.Get("Content-Type"))

--- a/athenahealth/httpclient_test.go
+++ b/athenahealth/httpclient_test.go
@@ -456,7 +456,7 @@ func TestHTTPClient_PostFormReader_stream(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(http.MethodPost, r.Method)
 
-		r.ParseForm()
+		assert.NoError(r.ParseForm())
 		inputStr := r.Form.Get("file")
 		fileBytes, err := base64.StdEncoding.DecodeString(inputStr)
 		assert.NoError(err)

--- a/athenahealth/insurance_test.go
+++ b/athenahealth/insurance_test.go
@@ -40,7 +40,7 @@ func TestHTTPClient_CreatePatientInsurancePackage(t *testing.T) {
 		assert.Equal(r.Form.Get("sequencenumber"), strconv.Itoa(opts.SequenceNumber))
 
 		b, _ := os.ReadFile("./resources/CreatePatientInsurancePackage.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -81,7 +81,7 @@ func TestHTTPClient_UpdatePatientInsurancePackage(t *testing.T) {
 		assert.Equal(r.Form.Get("newsequencenumber"), strconv.Itoa(*opts.NewSequenceNumber))
 
 		b, _ := os.ReadFile("./resources/UpdatePatientInsurancePackage.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -99,14 +99,14 @@ func TestHTTPClient_DeletePatientInsurancePackage(t *testing.T) {
 	called := false
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "cancellationnote=foo")
 
 		called = true
 
 		b, _ := os.ReadFile("./resources/DeletePatientInsurancePackage.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -133,7 +133,7 @@ func TestHTTPClient_ReactivatePatientInsurancePackage(t *testing.T) {
 		assert.Equal(r.Form.Get("expirationdate"), expDate.Format("01/02/2006"))
 
 		b, _ := os.ReadFile("./resources/ReactivatePatientInsurancePackage.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -158,7 +158,7 @@ func TestHTTPClient_ListPatientInsurancePackages(t *testing.T) {
 		assert.Equal(r.Form.Get("showcancelled"), "true")
 
 		b, _ := os.ReadFile("./resources/ListPatientInsurancePackages.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -186,7 +186,7 @@ func TestHTTPClient_UploadPatientInsuranceCardImage(t *testing.T) {
 		assert.Equal(deptID, r.FormValue("departmentid"))
 
 		b, _ := os.ReadFile("./resources/UploadPatientInsuranceCardImage.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -213,7 +213,7 @@ func TestHTTPClient_GetPatientInsurancePackage(t *testing.T) {
 		assert.Equal("/patients/1/insurances/2/image", r.URL.String())
 
 		b, _ := os.ReadFile("./resources/GetPatientInsuranceCardImage.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/lab_results_test.go
+++ b/athenahealth/lab_results_test.go
@@ -43,7 +43,7 @@ func TestHTTPClient_ListLabResults(t *testing.T) {
 		assert.Equal(startDate.Format("01/02/2006"), r.URL.Query().Get("startdate"))
 
 		b, _ := os.ReadFile("./resources/ListLabResults.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -98,7 +98,7 @@ func TestHTTPClient_AddLabResultDocument(t *testing.T) {
 		assert.Equal("16:41", obsTime)
 
 		b, _ := os.ReadFile("./resources/AddLabResultDocument.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -137,7 +137,7 @@ func TestHTTPClient_AddLabResultDocument_observation_without_time(t *testing.T) 
 		assert.Equal("", obsTime)
 
 		b, _ := os.ReadFile("./resources/AddLabResultDocument.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -165,7 +165,7 @@ func TestHTTPClient_ListChangedLabResults(t *testing.T) {
 		assert.Equal(strconv.FormatBool(showPortalOnly), r.URL.Query().Get("showportalonly"))
 
 		b, _ := os.ReadFile("./resources/ListChangedLabResults.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/medications_test.go
+++ b/athenahealth/medications_test.go
@@ -21,7 +21,7 @@ func TestHTTPClient_ListMedications(t *testing.T) {
 		assert.Equal(MedicationTypeActive, r.URL.Query().Get("medicationtype"))
 
 		b, _ := os.ReadFile("./resources/ListMedications.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -48,7 +48,7 @@ func TestHTTPClient_ListMedications_None(t *testing.T) {
 
 		b := []byte(`{
 			"patientneedsdownloadconsent": false,"medications": [],"patientdownloadconsent": true,"nomedicationsreported": false}`)
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -70,7 +70,7 @@ func TestHTTPClient_SearchMedications(t *testing.T) {
 		assert.Equal(searchVal, r.URL.Query().Get("searchvalue"))
 
 		b, _ := os.ReadFile("./resources/SearchMedications.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -92,7 +92,7 @@ func TestHTTPClient_SearchMedications_None(t *testing.T) {
 		assert.Equal(searchVal, r.URL.Query().Get("searchvalue"))
 
 		b := []byte("[]")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/patients_test.go
+++ b/athenahealth/patients_test.go
@@ -26,7 +26,7 @@ func TestHTTPClient_GetPatient(t *testing.T) {
 		assert.Equal("true", r.URL.Query().Get("showallpatientdepartmentstatus"))
 
 		b, _ := os.ReadFile("./resources/GetPatient.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -54,7 +54,7 @@ func TestHTTPClient_GetPatients(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/GetPatient.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -80,7 +80,7 @@ func TestHTTPClient_ListPatients(t *testing.T) {
 		assert.Equal("i", r.URL.Query().Get("status"))
 
 		b, _ := os.ReadFile("./resources/ListPatients.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -152,7 +152,7 @@ func TestHTTPClient_ListChangedPatients(t *testing.T) {
 		assert.Equal("06/02/2020 12:30:45", r.URL.Query().Get("showprocessedenddatetime"))
 
 		b, _ := os.ReadFile("./resources/ListChangedPatients.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -203,7 +203,7 @@ func TestHTTPClient_UpdatePatientInformationVerificationDetails(t *testing.T) {
 		assert.Equal(signerRelationshipToPatientID, r.FormValue("signerrelationshiptopatientid"))
 
 		b, _ := os.ReadFile("./resources/UpdatePatientInformationVerificationDetails.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -242,7 +242,7 @@ func TestHTTPClient_UpdatePatientMedicationHistoryConsent(t *testing.T) {
 		assert.Equal(signatureName, r.FormValue("signaturename"))
 
 		b, _ := os.ReadFile("./resources/UpdatePatientMedicationHistoryConsent.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -270,7 +270,7 @@ func TestHTTPClient_GetPatientCustomFields(t *testing.T) {
 		assert.Equal(departmentID, r.URL.Query().Get("departmentid"))
 
 		b, _ := os.ReadFile("./resources/GetPatientCustomFields.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -313,7 +313,7 @@ func TestHTTPClient_UpdatePatientCustomFields(t *testing.T) {
 		assert.Equal(departmentID, r.FormValue("departmentid"))
 		assert.Equal(`[{"customfieldid":"3","customfieldvalue":"foobar","optionid":"4"}]`, r.FormValue("customfields"))
 		b, _ := os.ReadFile("./resources/UpdatePatientCustomFields.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -336,7 +336,7 @@ func TestHTTPClient_ListPatientsMatchingCustomField(t *testing.T) {
 		assert.Contains(r.URL.Path, "/patients/customfields/"+opts.CustomFieldID+"/"+opts.CustomFieldValue)
 
 		b, _ := os.ReadFile("./resources/ListPatientsMatchingCustomField.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -401,7 +401,7 @@ func TestHTTPClient_CreatePatient(t *testing.T) {
 		}
 
 		b, _ := os.ReadFile("./resources/CreatePatient.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -519,7 +519,7 @@ func TestHTTPClient_UpdatePatient(t *testing.T) {
 		assert.Equal(r.Form.Get("zip"), *opts.Zip)
 
 		b, _ := os.ReadFile("./resources/UpdatePatient.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/patients_test.go
+++ b/athenahealth/patients_test.go
@@ -126,7 +126,7 @@ func TestHTTPClient_UpdatePatientPhoto(t *testing.T) {
 	data := []byte("Hello World!")
 
 	h := func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		assert.NoError(r.ParseForm())
 
 		assert.Equal(base64.StdEncoding.EncodeToString(data), r.Form.Get("image"))
 	}

--- a/athenahealth/physical_exam_test.go
+++ b/athenahealth/physical_exam_test.go
@@ -14,7 +14,7 @@ func TestHTTPClient_GetPhysicalExam(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/PhysicalExam.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/prescriptions_test.go
+++ b/athenahealth/prescriptions_test.go
@@ -19,7 +19,7 @@ func TestHTTPClient_ListChangedPrescriptions(t *testing.T) {
 		assert.Equal(strconv.FormatBool(leaveUnprocessed), r.URL.Query().Get("leaveunprocessed"))
 
 		b, _ := os.ReadFile("./resources/ListChangedPrescriptions.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/problems_test.go
+++ b/athenahealth/problems_test.go
@@ -19,7 +19,7 @@ func TestHTTPClient_ListProblems(t *testing.T) {
 		assert.Equal("true", r.URL.Query().Get("showdiagnosisinfo"))
 
 		b, _ := os.ReadFile("./resources/ListProblems.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -47,7 +47,7 @@ func TestHTTPClient_ListChangedProblems(t *testing.T) {
 		assert.Equal("06/02/2020 12:30:45", r.URL.Query().Get("showprocessedenddatetime"))
 
 		b, _ := os.ReadFile("./resources/ListChangedProblems.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/providers_test.go
+++ b/athenahealth/providers_test.go
@@ -15,7 +15,7 @@ func TestHTTPClient_GetProvider(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/GetProvider.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -36,7 +36,7 @@ func TestHTTPClient_ListChangedProviders(t *testing.T) {
 		assert.Equal("06/02/2020 12:30:45", r.URL.Query().Get("showprocessedenddatetime"))
 
 		b, _ := os.ReadFile("./resources/ListChangedProviders.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -61,7 +61,7 @@ func TestHTTPClient_ListProviders(t *testing.T) {
 		assert.Equal("true", r.URL.Query().Get("showallproviderids"))
 
 		b, _ := os.ReadFile("./resources/ListProviders.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/ratelimiter/redis_test.go
+++ b/athenahealth/ratelimiter/redis_test.go
@@ -33,7 +33,7 @@ func TestRedis_Allowed(t *testing.T) {
 	for range 10 {
 		wg.Add(1)
 		go func() {
-			rateLimiter.Allowed(context.Background(), true)
+			_, _ = rateLimiter.Allowed(context.Background(), true)
 			wg.Done()
 		}()
 	}

--- a/athenahealth/subscriptions_test.go
+++ b/athenahealth/subscriptions_test.go
@@ -15,7 +15,7 @@ func TestHTTPClient_GetSubscription(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/GetSubscription.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -32,7 +32,7 @@ func TestHTTPClient_ListSubscriptionEvents(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/ListSubscriptionEvents.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)
@@ -50,7 +50,7 @@ func TestHTTPClient_Subscribe(t *testing.T) {
 	called := false
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "eventname=UpdateAppointment")
 
@@ -75,7 +75,7 @@ func TestHTTPClient_Unsubscribe(t *testing.T) {
 	called := false
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 
 		assert.Contains(string(reqBody), "eventname=UpdateAppointment")
 

--- a/athenahealth/telehealth_test.go
+++ b/athenahealth/telehealth_test.go
@@ -14,7 +14,7 @@ func TestHTTPClient_GetTelehealthInviteURL(t *testing.T) {
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		b, _ := os.ReadFile("./resources/GetTelehealthInviteURL.json")
-		w.Write(b)
+		_, _ = w.Write(b)
 	}
 
 	athenaClient, ts := testClient(h)

--- a/athenahealth/tokencacher/file.go
+++ b/athenahealth/tokencacher/file.go
@@ -54,7 +54,7 @@ func (f *File) Get(ctx context.Context) (string, error) {
 	c := &fileCache{}
 	err = json.Unmarshal(contents, c)
 	if err != nil {
-		return "", fmt.Errorf("Error unmarshaling token: %s", err)
+		return "", fmt.Errorf("error unmarshaling token: %s", err)
 	}
 
 	if time.Now().After(c.ExpiresAt) {

--- a/athenahealth/tokencacher/file.go
+++ b/athenahealth/tokencacher/file.go
@@ -54,7 +54,7 @@ func (f *File) Get(ctx context.Context) (string, error) {
 	c := &fileCache{}
 	err = json.Unmarshal(contents, c)
 	if err != nil {
-		return "", fmt.Errorf("error unmarshaling token: %s", err)
+		return "", fmt.Errorf("error unmarshaling token: %w", err)
 	}
 
 	if time.Now().After(c.ExpiresAt) {

--- a/athenahealth/tokencacher/file_test.go
+++ b/athenahealth/tokencacher/file_test.go
@@ -18,7 +18,7 @@ func TestFile_Get(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer func() { _ = os.Remove(file.Name()) }()
 
 	c := &fileCache{
 		Token:     "foo",
@@ -26,7 +26,7 @@ func TestFile_Get(t *testing.T) {
 	}
 
 	b, _ := json.Marshal(c)
-	os.WriteFile(file.Name(), b, 0644)
+	assert.NoError(os.WriteFile(file.Name(), b, 0644))
 
 	cacher := NewFile(file.Name())
 
@@ -43,7 +43,7 @@ func TestFile_Get_ErrTokenNotExist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer func() { _ = os.Remove(file.Name()) }()
 
 	cacher := NewFile(file.Name())
 
@@ -61,7 +61,7 @@ func TestFile_Get_ErrTokenExpired(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer func() { _ = os.Remove(file.Name()) }()
 
 	c := &fileCache{
 		Token:     "foo",
@@ -69,7 +69,7 @@ func TestFile_Get_ErrTokenExpired(t *testing.T) {
 	}
 
 	b, _ := json.Marshal(c)
-	os.WriteFile(file.Name(), b, 0644)
+	assert.NoError(os.WriteFile(file.Name(), b, 0644))
 
 	cacher := NewFile(file.Name())
 
@@ -87,7 +87,7 @@ func TestFile_Set(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer func() { _ = os.Remove(file.Name()) }()
 
 	cacher := NewFile(file.Name())
 
@@ -98,7 +98,7 @@ func TestFile_Set(t *testing.T) {
 
 	b, _ := os.ReadFile(file.Name())
 	c := &fileCache{}
-	json.Unmarshal(b, c)
+	assert.NoError(json.Unmarshal(b, c))
 
 	assert.NoError(err)
 	assert.Equal(token, c.Token)

--- a/athenahealth/tokencacher/redis_test.go
+++ b/athenahealth/tokencacher/redis_test.go
@@ -22,7 +22,7 @@ func TestRedis_Get(t *testing.T) {
 
 	expectedToken := "foo"
 
-	s.Set(RedisDefaultKey, expectedToken)
+	assert.NoError(s.Set(RedisDefaultKey, expectedToken))
 	s.SetTTL(RedisDefaultKey, time.Minute*1)
 
 	cacher := NewRedis(redis.NewClient(&redis.Options{

--- a/athenahealth/tokenprovider/default.go
+++ b/athenahealth/tokenprovider/default.go
@@ -67,7 +67,7 @@ func (d *Default) Provide(ctx context.Context) (string, time.Time, error) {
 	if err != nil {
 		return "", time.Now(), err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		return "", time.Now(), fmt.Errorf("%s", res.Status)

--- a/athenahealth/tokenprovider/default_test.go
+++ b/athenahealth/tokenprovider/default_test.go
@@ -43,7 +43,7 @@ func TestDefault_Provide(t *testing.T) {
 		assert.Equal(r.FormValue("grant_type"), "client_credentials")
 
 		b, _ := json.Marshal(authRes)
-		w.Write(b)
+		_, _ = w.Write(b)
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
## Summary

Instruments `go-athenahealth` CI with Datadog Test Optimization (CI Visibility) via Orchestrion (dd-trace-go compile-time toolexec). Test results will appear in Datadog Test Optimization under \`service:go-athenahealth\`.

## What changed

### Test job — architecture

- **On `pull_request`:** plain \`gotestsum --format testdox -- -race ./...\`. No secrets involved.
- **On `push` to main/master:** tries Datadog CI Visibility path. If \`DD_API_KEY\` is absent (secret not yet provisioned), emits a notice and falls back to plain \`gotestsum\` so the required check always passes. If \`DD_API_KEY\` is present, installs Orchestrion v1.12.0 and runs \`orchestrion go test -race ./...\`.

The push-gated design keeps secrets off PRs entirely (no fork-exfiltration risk on this public repo) while ensuring main never loses test execution.

### Test job — other changes

- \`actions/checkout@v2\`, \`actions/setup-go@v2\` pinned to immutable commit SHAs (v7.0.1, v7.0.0); trailing comments carry resolved patch version
- \`go-version: '1.25'\` — required by orchestrion v1.12.0 and dd-trace-go/v2; setup-go exports \`GOTOOLCHAIN=local\` so lower versions fail at install time
- \`gotestsum@v1.12.0\` for structured test output
- \`-race\` flag added — aligns CI with the Makefile
- \`DD_SITE: datadoghq.com\` set explicitly; \`DD_CIVISIBILITY_LOGS_ENABLED=false\` set explicitly
- Orchestrion wrapper (\`orchestrion go test\`) used instead of \`-toolexec\` to keep dd-trace-go out of this library module's \`go.mod\`

### Lint job

- \`golangci/golangci-lint-action@v2\` pinned to commit SHA (v9.3.0) + \`version: v2.12.2\`
- \`--tests=false\` dropped — v2 defaults expose test files; fixes applied across test suite
- \`%w\` fix in \`tokencacher/file.go\`

### httpclient.go — race fix (scope: lint-forced by \`-race\`)

\`-race\` caught a data race on \`sizeRecordingReader.size\`: the HTTP transport's write goroutine and the caller's read of \`srBody.size\` after \`Do()\` returns ran concurrently. Fixed with \`atomic.Int64\` on the \`size\` field — zero behavioural change, streaming preserved. The \`io.ReadAll\` buffering approach tried in an earlier commit defeated \`AddDocumentReader\` / \`AddClinicalDocumentReader\`'s streaming contract and silently changed \`Transfer-Encoding: chunked\` to \`Content-Length\`; reverted.

### Why not the composite action?

\`harbor-github-actions\` is a private org repo requiring explicit per-repo access grants. \`go-athenahealth\` is not on the allow-list, so \`uses: Harbor-Engineering/harbor-github-actions/...\` fails. Steps are inlined as a workaround. The TODO marks where to revert once access is granted — note the swap is **not** behaviour-preserving: the composite action also uploads JUnit XML artifacts and publishes a job summary (\`publish-test-summary\`) that are not inlined here.

## Testing

- [x] CI passes on this PR (plain gotestsum path)
- [ ] After merge, verify test results appear in Datadog Test Optimization filtered by \`service:go-athenahealth\` (requires DD_API_KEY provisioned per PLATENG-354)

## Related

- PLATENG-355 — CI Visibility adoption rollout
- PLATENG-354 — \`DD_API_KEY\` org secret provisioning
- harbor-github-actions PR #16 — merged the \`run-go-tests-and-publish\` action

## Governance note (PLATENG-355 rollout)

For the record before this pattern travels to other repos:
- Datadog BAA coverage confirmed with CI Visibility in scope
- \`DD_CIVISIBILITY_LOGS_ENABLED=false\` set explicitly
- This repo's fixtures are synthetic (Jane Doe / John Smith / 555 numbers); per-repo "fixtures are synthetic" gate added to PLATENG-355 rollout checklist
- Two pre-existing phone numbers in upstream fixtures (\`8608105503\`, \`8608183849\`, \`8605544444\`) noted; scrubbing deferred to PLATENG-355 checklist before pattern reaches repos with real athenahealth cassettes